### PR TITLE
Retrieve command results separately

### DIFF
--- a/empire
+++ b/empire
@@ -125,7 +125,7 @@ def get_permanent_token(conn):
 #    GET/POST http://localhost:1337/api/agents/Y/clear       clears the result buffer for agent Y
 #    GET/POST http://localhost:1337/api/agents/Y/kill        kill agent Y
 #
-#    GET      http://localhost:1337/api/results/X            return result X
+#    GET      http://localhost:1337/api/results/agent/X            return result X
 #
 #    GET      http://localhost:1337/api/reporting            return all logged events
 #    GET      http://localhost:1337/api/reporting/X          return logged event for the given ID X
@@ -892,7 +892,10 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
 
             #create new result item
             curr = conn.cursor()
-            taskID = curr.execute("INSERT INTO results (agent, result) VALUES(?, '')", [agentSessionID]).lastrowid
+            pk = curr.execute("select max(id) from results where agent=?", [agentSessionID]).fetchone()[0];
+            if pk is None:
+                pk=0
+            taskID = curr.execute("INSERT INTO results (id, agent, result) VALUES(?, ?, '')", [pk+1, agentSessionID]).lastrowid
             curr.close()
 
             # append our new json-ified task and update the backend
@@ -998,12 +1001,14 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
 
         return jsonify({'success': True})
 
-    @app.route('/api/results/<int:resultID>', methods=['GET'])
-    def get_result(resultID):
+    @app.route('/api/results/<string:agent_name>/<int:resultID>', methods=['GET'])
+    def get_result(agent_name, resultID):
 
-        agentResult, agentName = execute_db_query(conn, 'SELECT result,agent FROM results WHERE id=?', [resultID])[0]
-
-        return jsonify({'result': agentResult, 'agent': agentName})
+        result = execute_db_query(conn, 'SELECT result FROM results WHERE id=? and agent=?', [resultID, agent_name])
+        if (len(result)):
+            return jsonify({'result': result})
+        else:
+            return jsonify({'result':''})
 
 
     @app.route('/api/creds', methods=['GET'])

--- a/empire
+++ b/empire
@@ -125,7 +125,10 @@ def get_permanent_token(conn):
 #    GET/POST http://localhost:1337/api/agents/Y/clear       clears the result buffer for agent Y
 #    GET/POST http://localhost:1337/api/agents/Y/kill        kill agent Y
 #
+#    GET      http://localhost:1337/api/results/X            return result X
+#
 #    GET      http://localhost:1337/api/reporting            return all logged events
+#    GET      http://localhost:1337/api/reporting/X          return logged event for the given ID X
 #    GET      http://localhost:1337/api/reporting/agent/X    return all logged events for the given agent name X
 #    GET      http://localhost:1337/api/reporting/type/Y     return all logged events of type Y (checkin, task, result, rename)
 #    GET      http://localhost:1337/api/reporting/msg/Z      return all logged events matching message Z, wildcards accepted
@@ -386,7 +389,6 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
         """
         Executes a given module name with the specified parameters.
         """
-
         # ensure the 'Agent' argument is set
         if not request.json or not 'Agent' in request.json:
             abort(400)
@@ -473,25 +475,29 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
             else:
                 taskCommand = "TASK_CMD_WAIT"
 
+        #create new result item
+        curr = conn.cursor()
         if sessionID.lower() == "all":
-
+            taskIDs = []
             for agent in main.agents.get_agents():
                 sessionID = agent[1]
-                main.agents.add_agent_task(sessionID, taskCommand, moduleData)
+                taskIDs.append(main.agents.add_agent_task(sessionID, taskCommand, moduleData))
                 msg = "tasked agent %s to run module %s" %(sessionID, module_name)
                 main.agents.save_agent_log(sessionID, msg)
 
             msg = "tasked all agents to run module %s" %(module_name)
-            return jsonify({'success': True, 'msg':msg})
+            curr.close()
+            return jsonify({'success': True, 'msg':msg, "taskIDs": taskIDs})
 
         else:
+
             # set the agent's tasking in the cache
-            main.agents.add_agent_task(sessionID, taskCommand, moduleData)
+            taskID = main.agents.add_agent_task(sessionID, taskCommand, moduleData)
 
             # update the agent log
             msg = "tasked agent %s to run module %s" %(sessionID, module_name)
             main.agents.save_agent_log(sessionID, msg)
-            return jsonify({'success': True, 'msg':msg})
+            return jsonify({'success': True, 'msg':msg, "taskID": taskID})
 
 
     @app.route('/api/modules/search', methods=['POST'])
@@ -875,10 +881,8 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
             return make_response(jsonify( {'error': 'agent name %s not found' %(agent_name) } ), 404)
 
         command = request.json['command']
-
         for agentNameID in agentNameIDs:
             (agentName, agentSessionID) = agentNameID
-
             # get existing agent taskings for each agent
             agentTasks = execute_db_query(conn, 'SELECT taskings FROM agents WHERE session_id like ?', [agentSessionID])[0]
             if(agentTasks and agentTasks[0]):
@@ -886,15 +890,20 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
             else:
                 agentTasks = []
 
+            #create new result item
+            curr = conn.cursor()
+            taskID = curr.execute("INSERT INTO results (agent, result) VALUES(?, '')", [agentSessionID]).lastrowid
+            curr.close()
+
             # append our new json-ified task and update the backend
-            agentTasks.append(['TASK_SHELL', command])
+            agentTasks.append(['TASK_SHELL', command, taskID])
 
             execute_db_query(conn, "UPDATE agents SET taskings=? WHERE session_id=?", [json.dumps(agentTasks), agentSessionID])
 
             timeStamp = strftime("%Y-%m-%d %H:%M:%S", localtime())
-            execute_db_query(conn, "INSERT INTO reporting (name,event_type,message,time_stamp) VALUES (?,?,?,?)", (agentName,"task","TASK_SHELL - " + command[0:50], timeStamp ))
+            execute_db_query(conn, "INSERT INTO reporting (name,event_type,message,time_stamp, taskID) VALUES (?,?,?,?,?)", (agentName,"task","TASK_SHELL - " + command[0:50], timeStamp, taskID ))
 
-        return jsonify({'success': True})
+        return jsonify({'success': True, "taskID": taskID})
 
 
     @app.route('/api/agents/<string:agent_name>/rename', methods=['POST'])
@@ -974,8 +983,13 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
             else:
                 agentTasks = []
 
+            #create new result item
+            curr = conn.cursor()
+            taskID = curr.execute("INSERT INTO results (agent, result) VALUES(?, '')", [agentSessionID]).lastrowid
+            curr.close()
+
             # append our new json-ified task and update the backend
-            agentTasks.append(['TASK_EXIT', ''])
+            agentTasks.append(['TASK_EXIT', '', taskID])
 
             execute_db_query(conn, "UPDATE agents SET taskings=? WHERE session_id=?", [json.dumps(agentTasks), agentSessionID])
 
@@ -983,6 +997,13 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
             execute_db_query(conn, "INSERT INTO reporting (name,event_type,message,time_stamp) VALUES (?,?,?,?)", (agentName,"task","TASK_EXIT", timeStamp ))
 
         return jsonify({'success': True})
+
+    @app.route('/api/results/<int:resultID>', methods=['GET'])
+    def get_result(resultID):
+
+        agentResult, agentName = execute_db_query(conn, 'SELECT result,agent FROM results WHERE id=?', [resultID])[0]
+
+        return jsonify({'result': agentResult, 'agent': agentName})
 
 
     @app.route('/api/creds', methods=['GET'])
@@ -1009,10 +1030,24 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
         reportingEvents = []
         
         for reportingEvent in reportingRaw:
-            [ID, name, eventType, message, timestamp] = reportingEvent
-            reportingEvents.append({"ID":ID, "agentname":name, "event_type":eventType, "message":message, "timestamp":timestamp})
+            [ID, name, eventType, message, timestamp, taskID] = reportingEvent
+            if( not taskID):
+                taskID=""
+            reportingEvents.append({"ID":ID, "agentname":name, "event_type":eventType, "message":message, "timestamp":timestamp, "taskID":taskID})
 
         return jsonify({'reporting' : reportingEvents})
+
+    @app.route('/api/reporting/<int:reportID>', methods=['GET'])
+    def get_reporting_id(reportID):
+        result = execute_db_query(conn, 'SELECT * FROM reporting WHERE id=?', [reportID])
+        if(len(result)):
+            [ID, name, eventType, message, timestamp, taskID] = result[0]
+            if( not taskID):
+                taskID=""
+            event = {"ID":ID, "agentname":name, "event_type":eventType, "message":message, "timestamp":timestamp, "taskID":taskID}
+            return jsonify({"reporting":event})
+        else:
+            return jsonify({"reporting":""})
 
 
     @app.route('/api/reporting/agent/<string:reporting_agent>', methods=['GET'])
@@ -1033,8 +1068,10 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
         reportingEvents = []
         
         for reportingEvent in reportingRaw:
-            [ID, name, eventType, message, timestamp] = reportingEvent
-            reportingEvents.append({"ID":ID, "agentname":name, "event_type":eventType, "message":message, "timestamp":timestamp})
+            [ID, name, eventType, message, timestamp, taskID] = reportingEvent
+            if( not taskID):
+                taskID=""
+            reportingEvents.append({"ID":ID, "agentname":name, "event_type":eventType, "message":message, "timestamp":timestamp, "taskID":taskID})
 
         return jsonify({'reporting' : reportingEvents})
 
@@ -1049,8 +1086,10 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
         reportingEvents = []
         
         for reportingEvent in reportingRaw:
-            [ID, name, eventType, message, timestamp] = reportingEvent
-            reportingEvents.append({"ID":ID, "agentname":name, "event_type":eventType, "message":message, "timestamp":timestamp})
+            [ID, name, eventType, message, timestamp, taskID] = reportingEvent
+            if( not taskID):
+                taskID=""
+            reportingEvents.append({"ID":ID, "agentname":name, "event_type":eventType, "message":message, "timestamp":timestamp, "taskID":taskID})
 
         return jsonify({'reporting' : reportingEvents})
 
@@ -1065,8 +1104,10 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
         reportingEvents = []
         
         for reportingEvent in reportingRaw:
-            [ID, name, eventType, message, timestamp] = reportingEvent
-            reportingEvents.append({"ID":ID, "agentname":name, "event_type":eventType, "message":message, "timestamp":timestamp})
+            [ID, name, eventType, message, timestamp, taskID] = reportingEvent
+            if( not taskID):
+                taskID=""
+            reportingEvents.append({"ID":ID, "agentname":name, "event_type":eventType, "message":message, "timestamp":timestamp, "taskID":taskID})
 
         return jsonify({'reporting' : reportingEvents})
 

--- a/setup/setup_database.py
+++ b/setup/setup_database.py
@@ -196,9 +196,10 @@ c.execute('''CREATE TABLE "credentials" (
     )''')
 
 c.execute( '''CREATE TABLE "results" (
-    "id" integer PRIMARY KEY,
+    "id" integer,
     "result" text,
-    "agent" text
+    "agent" text,
+    PRIMARY KEY(id, agent)
 )''')
 
 # event_types -> checkin, task, result, rename

--- a/setup/setup_database.py
+++ b/setup/setup_database.py
@@ -190,11 +190,16 @@ c.execute('''CREATE TABLE "credentials" (
     "domain" text,
     "username" text,
     "password" text,
-    "host" text, 
+    "host" text,
     "sid" text,
     "notes" text
     )''')
 
+c.execute( '''CREATE TABLE "results" (
+    "id" integer PRIMARY KEY,
+    "result" text,
+    "agent" text
+)''')
 
 # event_types -> checkin, task, result, rename
 c.execute('''CREATE TABLE "reporting" (
@@ -202,7 +207,9 @@ c.execute('''CREATE TABLE "reporting" (
     "name" text,
     "event_type" text,
     "message" text,
-    "time_stamp" text
+    "time_stamp" text,
+    "taskID" integer,
+    foreign key("taskID") references results(id)
     )''')
 
 


### PR DESCRIPTION
This pull request adds an extension to the API, and some slight modifications to the communication, and result handling functions.
 The idea is to separate the results of executed tasks, and make those available via the API.

This means adding a task id field to the packet structure, which will be returned with eventual results, making it possible to identify the command from which the current result originates. For long running tasks such as keyloggers, a hashmap is kept on the agent, which matches jobnames to task id's.
