### PR TITLE
REST API authentication issue

### DIFF
--- a/empire
+++ b/empire
@@ -1087,7 +1087,10 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
         # try to prevent some basic bruting
         time.sleep(2)
         
-        if suppliedUsername == username and suppliedPassword == password:
+        username_str = ''.join(username)
+        password_str = ''.join(password)
+        
+        if suppliedUsername == username_str and suppliedPassword == password_str:
             return jsonify({'token': apiToken})
         else:
             return make_response('', 401)


### PR DESCRIPTION
API authentication fails because "username" and "password" variables are of type list which are compared to "suppliedUsername" and "suppliedPassword" which are of type unicode. Converting the list to string fixes the authentication bug.
