### PR TITLE
Fix agent staging over http_hop listeners.

### DIFF
--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -747,8 +747,16 @@ def send_message(packets=None):
                             sessionKey = self.mainMenu.agents.agents[sessionID]['sessionKey']
                             dispatcher.send("[*] Sending agent (stage 2) to %s at %s" % (sessionID, clientIP), sender='listeners/http')
 
+                            hopListenerName = request.headers.get('Hop-Name')
+                            try:
+                                hopListener = helpers.get_listener_options(hopListenerName)
+                                tempListenerOptions = copy.deepcopy(listenerOptions)
+                                tempListenerOptions['Host']['Value'] = hopListener['Host']['Value']
+                            except TypeError:
+                                tempListenerOptions = listenerOptions
+
                             # step 6 of negotiation -> server sends patched agent.ps1/agent.py
-                            agentCode = self.generate_agent(language=language, listenerOptions=listenerOptions)
+                            agentCode = self.generate_agent(language=language, listenerOptions=tempListenerOptions)
                             encryptedAgent = encryption.aes_encrypt_then_hmac(sessionKey, agentCode)
                             # TODO: wrap ^ in a routing packet?
 

--- a/lib/listeners/http_hop.py
+++ b/lib/listeners/http_hop.py
@@ -440,6 +440,7 @@ def send_message(packets=None):
             f.close()
 
             hopCode = hopCode.replace('REPLACE_SERVER', redirectHost)
+            hopCode = hopCode.replace('REPLACE_HOP_NAME', self.options['Name']['Value'])
 
             saveFolder = self.options['OutFolder']['Value']
             for uri in uris:


### PR DESCRIPTION
Fixes issue #370.

Tested on Python 2.7.5, CentOS 7.2, and PHP 5.4.45 (for the hop server)
hop.php now adds a header with the name of its hop listener, and the hop address is passed to generate_agent().