### PR TITLE
Fixed Get-SPNTicket multiple user SPNs bug

### DIFF
--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -551,6 +551,11 @@ Outputs a custom object containing the SamAccountName, DistinguishedName, Servic
                 $DistinguishedName = $Null
             }
 
+            # if a user has multiple SPNs we only take the first one otherwise the service ticket request fails miserably :)
+            if($UserSPN -is [System.DirectoryServices.ResultPropertyValueCollection]){
+                $UserSPN = $UserSPN[0]
+            }
+
             $Ticket = New-Object System.IdentityModel.Tokens.KerberosRequestorSecurityToken -ArgumentList $UserSPN
             $TicketByteStream = $Ticket.GetRequest()
             if ($TicketByteStream) {


### PR DESCRIPTION
When Get-SPNTicket receives a user object, if that user has multiple SPNs then the call to KerberosRequestorSecurityToken is failing because it is being fed an ResultPropertyValueCollection rather than a single SPN string, For this reason, Invoke-Kerberoast was very often returning the same wrong hash for many SPNs.

The proposed change fixes this bad behaviour. ;)