### PR TITLE
Add os module to backdoor_lnk.py

### DIFF
--- a/lib/modules/persistence/userland/backdoor_lnk.py
+++ b/lib/modules/persistence/userland/backdoor_lnk.py
@@ -1,3 +1,4 @@
+import os
 from lib.common import helpers
 
 class Module:


### PR DESCRIPTION
'import os' module missing. Using ExtFile throws error without it.