### PR TITLE
Alternate Proxy Credentials

### DIFF
--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -200,8 +200,13 @@ class Listener:
                         if proxyCreds.lower() == "default":
                             stager += helpers.randomize_capitalization("$wc.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials;")
                         else:
-                            # TODO: implement form for other proxy credentials
-                            pass
+                            domain = proxyCreds.split("\\")[0]
+                            creds = proxyCreds.split("\\")[1:]
+                            username = "".join(creds).split(":")[0]
+                            password = "".join("".join(creds).split(":")[1:])
+
+                            stager += helpers.randomize_capitalization("$wc.Proxy.Credentials = [System.Net.NetworkCredential]::new")
+                            stager += "('%s', '%s', '%s');" % (username, password, domain)
 
                 # TODO: reimplement stager retries?
 

--- a/lib/listeners/http_foreign.py
+++ b/lib/listeners/http_foreign.py
@@ -176,8 +176,13 @@ class Listener:
                         if proxyCreds.lower() == "default":
                             stager += helpers.randomize_capitalization("$wc.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials;")
                         else:
-                            # TODO: implement form for other proxy credentials
-                            pass
+                            domain = proxyCreds.split("\\")[0]
+                            creds = proxyCreds.split("\\")[1:]
+                            username = "".join(creds).split(":")[0]
+                            password = "".join("".join(creds).split(":")[1:])
+
+                            stager += helpers.randomize_capitalization("$wc.Proxy.Credentials = [System.Net.NetworkCredential]::new")
+                            stager += "('%s', '%s', '%s');" % (username, password, domain)
 
                 # TODO: reimplement stager retries?
 

--- a/lib/listeners/http_hop.py
+++ b/lib/listeners/http_hop.py
@@ -155,8 +155,13 @@ class Listener:
                         if proxyCreds.lower() == "default":
                             stager += helpers.randomize_capitalization("$wc.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials;")
                         else:
-                            # TODO: implement form for other proxy credentials
-                            pass
+                            domain = proxyCreds.split("\\")[0]
+                            creds = proxyCreds.split("\\")[1:]
+                            username = "".join(creds).split(":")[0]
+                            password = "".join("".join(creds).split(":")[1:])
+
+                            stager += helpers.randomize_capitalization("$wc.Proxy.Credentials = [System.Net.NetworkCredential]::new")
+                            stager += "('%s', '%s', '%s');" % (username, password, domain)
 
                 # TODO: reimplement stager retries?
 

--- a/lib/modules/powershell/lateral_movement/invoke_executemsbuild.py
+++ b/lib/modules/powershell/lateral_movement/invoke_executemsbuild.py
@@ -71,7 +71,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             },

--- a/lib/modules/powershell/lateral_movement/invoke_psexec.py
+++ b/lib/modules/powershell/lateral_movement/invoke_psexec.py
@@ -73,7 +73,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/lateral_movement/invoke_psremoting.py
+++ b/lib/modules/powershell/lateral_movement/invoke_psremoting.py
@@ -71,7 +71,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/lateral_movement/invoke_wmi.py
+++ b/lib/modules/powershell/lateral_movement/invoke_wmi.py
@@ -71,7 +71,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/lateral_movement/jenkins_script_console.py
+++ b/lib/modules/powershell/lateral_movement/jenkins_script_console.py
@@ -65,7 +65,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/lateral_movement/new_gpo_immediate_task.py
+++ b/lib/modules/powershell/lateral_movement/new_gpo_immediate_task.py
@@ -88,7 +88,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             },

--- a/lib/modules/powershell/management/psinject.py
+++ b/lib/modules/powershell/management/psinject.py
@@ -66,7 +66,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/management/spawn.py
+++ b/lib/modules/powershell/management/spawn.py
@@ -56,7 +56,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/management/spawnas.py
+++ b/lib/modules/powershell/management/spawnas.py
@@ -73,7 +73,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/persistence/elevated/registry.py
+++ b/lib/modules/powershell/persistence/elevated/registry.py
@@ -80,7 +80,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/persistence/elevated/schtasks.py
+++ b/lib/modules/powershell/persistence/elevated/schtasks.py
@@ -94,7 +94,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/persistence/elevated/wmi.py
+++ b/lib/modules/powershell/persistence/elevated/wmi.py
@@ -79,7 +79,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/persistence/userland/backdoor_lnk.py
+++ b/lib/modules/powershell/persistence/userland/backdoor_lnk.py
@@ -76,7 +76,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/persistence/userland/registry.py
+++ b/lib/modules/powershell/persistence/userland/registry.py
@@ -85,7 +85,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/persistence/userland/schtasks.py
+++ b/lib/modules/powershell/persistence/userland/schtasks.py
@@ -89,7 +89,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/privesc/ask.py
+++ b/lib/modules/powershell/privesc/ask.py
@@ -56,7 +56,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             } 

--- a/lib/modules/powershell/privesc/bypassuac.py
+++ b/lib/modules/powershell/privesc/bypassuac.py
@@ -59,7 +59,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             } 

--- a/lib/modules/powershell/privesc/bypassuac_eventvwr.py
+++ b/lib/modules/powershell/privesc/bypassuac_eventvwr.py
@@ -54,7 +54,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             } 

--- a/lib/modules/powershell/privesc/bypassuac_wscript.py
+++ b/lib/modules/powershell/privesc/bypassuac_wscript.py
@@ -56,7 +56,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             } 

--- a/lib/modules/powershell/privesc/ms16-032.py
+++ b/lib/modules/powershell/privesc/ms16-032.py
@@ -54,7 +54,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/privesc/powerup/service_exe_stager.py
+++ b/lib/modules/powershell/privesc/powerup/service_exe_stager.py
@@ -64,7 +64,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }

--- a/lib/modules/powershell/privesc/powerup/service_stager.py
+++ b/lib/modules/powershell/privesc/powerup/service_stager.py
@@ -58,7 +58,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             }     

--- a/lib/modules/powershell/privesc/powerup/write_dllhijacker.py
+++ b/lib/modules/powershell/privesc/powerup/write_dllhijacker.py
@@ -61,7 +61,7 @@ class Module:
                 'Value'         :   'default'
             },
             'ProxyCreds' : {
-                'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+                'Description'   :   'Proxy credentials ([domain.com\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
             } 


### PR DESCRIPTION
Updated http, http_foreign, and http_hop powershell launchers to specify alternate proxy credentials. This came in handy when code execution has been obtained under a local user account or SYSTEM. 

Also updated the ProxyCreds description to help users know that the top level is needed when specifying the domain.

Note: I did not update the generate_comms function with alternate proxy credentials as that may require a little more in depth changes. I also noticed that I was able to successfully interact with agents using alternate proxy credentials without changes to the comms functions, although I have only tested in one environment.