### PR TITLE
Add HTTP headers to avoid proxy caching

### DIFF
--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -97,7 +97,7 @@ class Listener:
                 'Value'         :   ''
             },
             'ServerVersion' : {
-                'Description'   :   'TServer header for the control server.',
+                'Description'   :   'Server header for the control server.',
                 'Required'      :   True,
                 'Value'         :   'Microsoft-IIS/7.5'
             }
@@ -684,6 +684,15 @@ def send_message(packets=None):
         def change_header(response):
             "Modify the default server version in the response."
             response.headers['Server'] = listenerOptions['ServerVersion']['Value']
+            return response
+
+
+        @app.after_request
+        def add_proxy_headers(response):
+            "Add HTTP headers to avoid proxy caching."
+            response.headers['Cache-Control'] = "no-cache, no-store, must-revalidate"
+            response.headers['Pragma'] = "no-cache"
+            response.headers['Expires'] = "0"
             return response
 
 

--- a/lib/listeners/http_com.py
+++ b/lib/listeners/http_com.py
@@ -98,7 +98,7 @@ class Listener:
                 'Value'         :   ''
             },
             'ServerVersion' : {
-                'Description'   :   'TServer header for the control server.',
+                'Description'   :   'Server header for the control server.',
                 'Required'      :   True,
                 'Value'         :   'Microsoft-IIS/7.5'
             }
@@ -455,6 +455,15 @@ class Listener:
         def change_header(response):
             "Modify the default server version in the response."
             response.headers['Server'] = listenerOptions['ServerVersion']['Value']
+            return response
+
+
+        @app.after_request
+        def add_proxy_headers(response):
+            "Add HTTP headers to avoid proxy caching."
+            response.headers['Cache-Control'] = "no-cache, no-store, must-revalidate"
+            response.headers['Pragma'] = "no-cache"
+            response.headers['Expires'] = "0"
             return response
 
 


### PR DESCRIPTION
Hi guys !

Recently, during a test, I was facing a connection problem between a client's LAN and my company's LAN. The initial connexion was performed but I could not run commands on the target (lastseenTime was always equals to checkinTime).
After a ~~long and painful~~ debugging session I figured out that the proxy between our LANs was applying a strict caching policy. My fix is to add HTTP headers in order to tell the proxy to not cache these pages.

Thanks for your amazing tool, version 2.0 is really powerfull ! :1st_place_medal: :smile: 

TPOSOS