### PR TITLE
Fix PKCS7 padding to be RFC compliant

### DIFF
--- a/lib/common/encryption.py
+++ b/lib/common/encryption.py
@@ -68,11 +68,8 @@ def pad(data):
     Performs PKCS#7 padding for 128 bit block size.
     """
 
-    if (len(data) % 16) == 0:
-        return data
-    else:
-        pad = 16 - (len(data) % 16)
-        return data + to_bufferable(chr(pad) * pad)
+    pad = 16 - (len(data) % 16)
+    return data + to_bufferable(chr(pad) * pad)
 
     # return str(s) + chr(16 - len(str(s)) % 16) * (16 - len(str(s)) % 16)
 
@@ -85,11 +82,7 @@ def depad(data):
         raise ValueError("invalid length")
 
     pad = _get_byte(data[-1])
-
-    if pad <= 16:
-        return data[:-pad]
-    else:
-        return data
+    return data[:-pad]
 
     # return s[:-(ord(s[-1]))]
 


### PR DESCRIPTION
Hi !

I've found a bug in your implementation of PKCS#7 padding. In the issue #458, I suspected a padding problem. Thus, by surrounding [this line](https://github.com/EmpireProject/Empire/blob/2.0_beta/data/agent/agent.ps1#L592 ) with a `try/catch` structure, it's possible to understand the cause of the bug. Indeed, the message caught was "Padding is invalid and cannot be removed"

According the [RF5652](https://tools.ietf.org/html/rfc5652#section-6.3), you have to pad like this :

```
                     01 -- if lth mod k = k-1
                  02 02 -- if lth mod k = k-2
                      .
                      .
                      .
            k k ... k k -- if lth mod k = 0
```
where `lth` is the length of the input and `k` the size of the block in byte (16 for Empire). The interesting case is when `lth mod k = 0`, in this case, you have to pad with `k` times the `k` value.

However, [here](https://github.com/EmpireProject/Empire/blob/2.0_beta/lib/common/encryption.py#L71) we can see that, if the data's length fits the block's length, the input is not padded. In consequence, when Powershell tries to depad it, an error occurs. So in my l33t fix, I've just removed the condition `if (len(data) % 16) == 0:` in order to always pad the data. This pull request should resolve #458.

Thanks again for your amazing tool, I've really appreciated dig into the code, learn a lot.
Thanks to my pythonic coworker (I know you read this) for your advices.

TPWSOS  :sunflower:

PS : Empyre is also impacted to it, but don't know if it's still maintained 