### PR TITLE
Improve shebangs

### DIFF
--- a/empire
+++ b/empire
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sqlite3, argparse, sys, argparse, logging, json, string
 import os, re, time, signal, copy, base64, pickle

--- a/setup/cert.sh
+++ b/setup/cert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # generate a self-signed CERT
 #openssl genrsa -des3 -out ./data/empire.orig.key 2048

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $EUID -ne 0 ]]; then
    echo " [!]This script must be run as root" 1>&2

--- a/setup/reset.sh
+++ b/setup/reset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $EUID -ne 0 ]]; then
    echo " [!]This script must be run as root" 1>&2

--- a/setup/setup_database.py
+++ b/setup/setup_database.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sqlite3, os, string, hashlib
 from Crypto.Random import random


### PR DESCRIPTION
Move all shebangs to `#!/usr/bin/env foo` to pick the appropriate binary
for the environment. This is especially useful on Macs where they may have
Python installed via Homebrew.