### PR TITLE
RESTfulAPI - api/admin/login fix

### DIFF
--- a/empire
+++ b/empire
@@ -165,12 +165,13 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
         username = dbUsername
     else:
         execute_db_query(conn, "UPDATE config SET api_username=?", username)
+        username = username[0]
 
     if not password:
         password = dbPassword
     else:
         execute_db_query(conn, "UPDATE config SET api_password=?", password)
-
+        password = password[0]
 
     class Namespace:
         """
@@ -1141,7 +1142,7 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
         # try to prevent some basic bruting
         time.sleep(2)
 
-        if suppliedUsername == username[0] and suppliedPassword == password[0]:
+        if suppliedUsername == username and suppliedPassword == password:
             return jsonify({'token': apiToken})
         else:
             return make_response('', 401)


### PR DESCRIPTION
**# ./empire -v**
2.0
**# python --version**
Python 2.7.13
**# uname -a**
Linux 4.9.0-kali3-amd64 #1 SMP Debian 4.9.16-1kali1 (2017-03-24) x86_64 GNU/Linux

**Details**
The api/admin/login doesn't authenticate properly - args passed from commandline are arrays and args fetched from db are just strings. These differences lead to wrong authentication process which results "HTTP/1.0 401 UNAUTHORIZED" response when username or password is fetched from db. 

My fix helps to authenticate properly without difference if the credentials are passed from commandline or not.