### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+data/empire.pem
+data/empire.db

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ data/misc/Obfuscated.ps1
 setup/xar*
 setup/bomutils/*
 .venv
+docker/docker-compose.override.yml

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ setup/xar*
 setup/bomutils/*
 .venv
 docker/docker-compose.override.yml
+.idea/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+# docker build -t empire . 
+# docker run -it --net host empire
+
+FROM ubuntu:zesty
+
+WORKDIR /opt/empire
+
+VOLUME /opt/empire/downloads
+
+# add setup files first for layer cache
+ADD ./setup /opt/empire/setup
+
+# allow db/cert to be created
+RUN mkdir /opt/empire/data
+
+RUN apt update && apt -y install lsb-release python-pip libssl-dev libxml2-dev libffi-dev git
+RUN pip install --upgrade pip
+
+RUN bash ./setup/install.sh
+
+# add remaining files
+ADD . /opt/empire/
+
+CMD ./empire

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ ADD ./setup /opt/empire/setup
 # allow db/cert to be created
 RUN mkdir /opt/empire/data
 
-RUN apt update && apt -y install lsb-release python-pip libssl-dev libxml2-dev libffi-dev git
+RUN apt-get update && apt-get -y install lsb-release python-pip libssl-dev libxml2-dev libffi-dev git
 RUN pip install --upgrade pip
 
 RUN bash ./setup/install.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,11 +15,11 @@ Prerequisites and caveats
 
 A note about networking
 ---------------------
-The default docker-compose.override.yml is configured for `host` networking mode which 
+The default `docker-compose.yml` is configured for `host` networking mode which 
 will allow all empire listener ports to automatically be exposed on the host system.
 This mode [isn't currently supported on mac](https://github.com/docker/for-mac/issues/1031)
-so the default network mode will need to be used with 
-[explicit port forwards](#use-port-forwards-for-listeners).
+so the default `bridge` network mode will need to be used with 
+[explicit port forwards (see below)](#use-port-forwards-for-listeners).
 
 Start container
 ---------------
@@ -37,6 +37,7 @@ $ docker attach empire
 
 Detach from container
 ---------------------
+Use the `[ctrl-p][ctrl-q]` hotkey sequence to break out of the Empire shell and drop back the system shell.
 ```console
 (Empire) >[ctrl-p][ctrl-q]
 $
@@ -50,10 +51,10 @@ $ docker-compose down
 
 Use port forward(s) for listeners
 ---------------------------------
-This is only required if not using `host` network mode (i.e. on Mac). In `docker-compose.override.yml` 
-comment out `network_mode: host` and uncomment `ports: ...` line and edit with desired port forwards
+This is only required using `bridge` network mode and not `host` network mode (i.e. on Mac). Rename `docker-compose.portfwd.yml` to `docker-compose.override.yml`
+and modify `ports:` entry as appropriate with desired port forwards.
 ```console
-$ cp docker-compose.override.yml.example docker-compose.override.yml
+$ cp docker-compose.portfwd.yml docker-compose.override.yml
 $ vim docker-compose.override.yml
 $ docker-compose up -d
 Recreating empire ...

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,61 @@
+Docker support
+==============
+
+Prerequisites and caveats
+-------------------------
+* Requires [`docker`](https://docs.docker.com/engine/installation/) 
+  and [`docker-compose`](https://docs.docker.com/compose/install/) be installed/configured
+* Downloads and agent logs persistently stored in volume mount at `downloads/`
+* Database (`data/empire.db`) and default generated certificate (`data/empire.pem`) 
+  currently not persisted outside of the container because of limitations in dir structure. This
+  means that database state will be lost if the docker containers are destroyed or recreated 
+  (i.e. `docker-compose down`).
+* All commands should be run from `docker/` subdirectory
+
+
+A note about networking
+---------------------
+The default docker-compose.override.yml is configured for `host` networking mode which 
+will allow all empire listener ports to automatically be exposed on the host system.
+This mode [isn't currently supported on mac](https://github.com/docker/for-mac/issues/1031)
+so the default network mode will need to be used with 
+[explicit port forwards](#use-port-forwards-for-listeners).
+
+Start container
+---------------
+```console
+$ docker-compose up -d
+```
+
+Attach to container
+-------------------
+Note that this is `docker` and not `docker-compose`
+```console
+$ docker attach empire
+(Empire) >
+```
+
+Detach from container
+---------------------
+```console
+(Empire) >[ctrl-p][ctrl-q]
+$
+```
+
+Destroy container
+-----------------
+```console
+$ docker-compose down
+```
+
+Use port forward(s) for listeners
+---------------------------------
+This is only required if not using `host` network mode (i.e. on Mac). In `docker-compose.override.yml` 
+comment out `network_mode: host` and uncomment `ports: ...` line and edit with desired port forwards
+```console
+$ cp docker-compose.override.yml.example docker-compose.override.yml
+$ vim docker-compose.override.yml
+$ docker-compose up -d
+Recreating empire ...
+Recreating empire ... done
+```

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  empire:
+    # Note that network_mode: host doesn't work properly on mac
+    # https://github.com/docker/for-mac/issues/1031
+    network_mode: host
+    #ports: ["80"]

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -1,7 +1,0 @@
-version: "3"
-services:
-  empire:
-    # Note that network_mode: host doesn't work properly on mac
-    # https://github.com/docker/for-mac/issues/1031
-    network_mode: host
-    #ports: ["80"]

--- a/docker/docker-compose.portfwd.yml
+++ b/docker/docker-compose.portfwd.yml
@@ -1,0 +1,9 @@
+# network_mode: host doesn't work properly on mac
+# https://github.com/docker/for-mac/issues/1031
+# use this file to port forward instead
+
+version: "3"
+services:
+  empire:
+    network_mode: bridge
+    ports: ["80"]

--- a/docker/docker-compose.psh.yml
+++ b/docker/docker-compose.psh.yml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  powershell:
+    image: microsoft/powershell
+    container_name: psh
+    tty: true
+    stdin_open: true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+    image: frohoff/empire
     tty: true
     stdin_open: true
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
     image: frohoff/empire
+    network_mode: host
     tty: true
     stdin_open: true
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  empire:
+    container_name: empire
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    tty: true
+    stdin_open: true
+    volumes:
+      - ./downloads:/opt/empire/downloads
+      #- ./empire:/opt/empire/empire
+      #- ./lib:/opt/empire/lib
+      #- ./data/module_source:/opt/empire/data/module_source
+

--- a/docker/docker-run.sh
+++ b/docker/docker-run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+docker build -t empire -f ./Dockerfile ..
+docker run -it empire

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -12,8 +12,10 @@ then
     cd ./setup
 fi
 
-wget https://bootstrap.pypa.io/get-pip.py
-python get-pip.py
+if ! which pip > /dev/null; then
+    wget https://bootstrap.pypa.io/get-pip.py
+    python get-pip.py
+fi
 
 version=$( lsb_release -r | grep -oP "[0-9]+" | head -1 )
 if lsb_release -d | grep -q "Fedora"; then
@@ -82,10 +84,9 @@ elif lsb_release -d | grep -q "Ubuntu"; then
 	pip install iptools
 	pip install pydispatcher
 	pip install flask
-	pip install pyOpenSSL
+	pip install 'pyopenssl==17.2.0'
 	pip install macholib
 	pip install dropbox
-	pip install 'pyopenssl==17.2.0'
 	pip install pyinstaller
 	pip install zlib_wrapper
 	pip install netifaces
@@ -114,8 +115,8 @@ else
 	 pip install macholib
 	 pip install dropbox
 	 pip install cryptography
-	 pip install pyOpenSSL
 	 pip install 'pyopenssl==17.2.0'
+	 pip install pyinstaller
 	 pip install zlib_wrapper
 	 pip install netifaces
 	 pip install M2Crypto

--- a/setup/setup_database.py
+++ b/setup/setup_database.py
@@ -21,7 +21,10 @@ punctuation = '!#%&()*+,-./:;<=>?@[]^_{|}~'
 
 # otherwise prompt the user for a set value to hash for the negotiation password
 if STAGING_KEY == "BLANK":
-    choice = raw_input("\n [>] Enter server negotiation password, enter for random generation: ")
+    try:
+      choice = raw_input("\n [>] Enter server negotiation password, enter for random generation: ")
+    except EOFError:
+      choice = ""
     if choice == "":
         # if no password is entered, generation something random
         STAGING_KEY = ''.join(random.sample(string.ascii_letters + string.digits + punctuation, 32))


### PR DESCRIPTION
Documentation available in [docker/README.md](https://github.com/frohoff/Empire/blob/docker/docker/README.md).

This iteration doesn't persist the database or cert outside of the container, but if the `empire.db` and `empire.pem` files could be moved into their own subdirectory it would allow them to be volume mounted separately from the rest of the files in `data` and persist outside of the container.