### PR TITLE
Force python2 usage

### DIFF
--- a/setup/setup_database.py
+++ b/setup/setup_database.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sqlite3, os, string, hashlib
 from Crypto.Random import random


### PR DESCRIPTION
See #385. Breaks install process on machines where python3 is default.