### PR TITLE
Add asterisk to modules requiring elevated context when tab completing search/usemodule (Issue 598)

### DIFF
--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -433,6 +433,7 @@ class MainMenu(cmd.Cmd):
 
     def do_usemodule(self, line):
         "Use an Empire module."
+        line = line.rstrip("*")
         if line not in self.modules.modules:
             print helpers.color("[!] Error: invalid module")
         else:
@@ -693,12 +694,26 @@ class MainMenu(cmd.Cmd):
         "Tab-complete an Empire module path."
 
         module_names = self.modules.modules.keys()
+
+		# suffix each module requiring elevated context with ' *' to indicate need for elevated context
+        for module_name in module_names:
+        	try:
+        		if self.modules.modules[module_name].info['NeedsAdmin']:
+        			module_names[module_names.index(module_name)] = (module_name+"*")
+        	# handle modules without a NeedAdmins info key
+        	except KeyError:
+        		pass
+
         if language:
             module_names = [ (module_name[len(language)+1:]) for module_name in module_names if module_name.startswith(language)]
 
         mline = line.partition(' ')[2]
+
         offs = len(mline) - len(text)
-        return [s[offs:] for s in module_names if s.startswith(mline)]
+
+        module_names = [s[offs:] for s in module_names if s.startswith(mline)]
+
+        return module_names
 
 
     def complete_reload(self, text, line, begidx, endidx):
@@ -1206,7 +1221,7 @@ class AgentsMenu(cmd.Cmd):
     def do_usemodule(self, line):
         "Use an Empire PowerShell module."
 
-        module = line.strip()
+        module = line.strip().rstrip("*")
 
         if module not in self.mainMenu.modules.modules:
             print helpers.color("[!] Error: invalid module")
@@ -1754,7 +1769,7 @@ class PowerShellAgentMenu(cmd.Cmd):
     def do_usemodule(self, line):
         "Use an Empire PowerShell module."
 
-        module = "powershell/%s" %(line.strip())
+        module = "powershell/%s" %(line.strip().rstrip("*"))
 
         if module not in self.mainMenu.modules.modules:
             print helpers.color("[!] Error: invalid module")
@@ -2551,7 +2566,7 @@ class PythonAgentMenu(cmd.Cmd):
     def do_usemodule(self, line):
         "Use an Empire Python module."
 
-        module = "python/%s" %(line.strip())
+        module = "python/%s" %(line.strip().rstrip("*"))
 
         if module not in self.mainMenu.modules.modules:
             print helpers.color("[!] Error: invalid module")
@@ -3260,7 +3275,7 @@ class ModuleMenu(cmd.Cmd):
     def do_usemodule(self, line):
         "Use an Empire PowerShell module."
 
-        module = line.strip()
+        module = line.strip().rstrip("*")
 
         if module not in self.mainMenu.modules.modules:
             print helpers.color("[!] Error: invalid module")

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -433,6 +433,7 @@ class MainMenu(cmd.Cmd):
 
     def do_usemodule(self, line):
         "Use an Empire module."
+        # Strip asterisks added by MainMenu.complete_usemodule()
         line = line.rstrip("*")
         if line not in self.modules.modules:
             print helpers.color("[!] Error: invalid module")
@@ -695,14 +696,14 @@ class MainMenu(cmd.Cmd):
 
         module_names = self.modules.modules.keys()
 
-		# suffix each module requiring elevated context with ' *' to indicate need for elevated context
+        # suffix each module requiring elevated context with '*'
         for module_name in module_names:
-        	try:
-        		if self.modules.modules[module_name].info['NeedsAdmin']:
-        			module_names[module_names.index(module_name)] = (module_name+"*")
-        	# handle modules without a NeedAdmins info key
-        	except KeyError:
-        		pass
+            try:
+                if self.modules.modules[module_name].info['NeedsAdmin']:
+                    module_names[module_names.index(module_name)] = (module_name+"*")
+            # handle modules without a NeedAdmins info key
+            except KeyError:
+                pass
 
         if language:
             module_names = [ (module_name[len(language)+1:]) for module_name in module_names if module_name.startswith(language)]
@@ -1221,6 +1222,7 @@ class AgentsMenu(cmd.Cmd):
     def do_usemodule(self, line):
         "Use an Empire PowerShell module."
 
+        # Strip asterisks added by MainMenu.complete_usemodule()
         module = line.strip().rstrip("*")
 
         if module not in self.mainMenu.modules.modules:
@@ -1769,6 +1771,7 @@ class PowerShellAgentMenu(cmd.Cmd):
     def do_usemodule(self, line):
         "Use an Empire PowerShell module."
 
+        # Strip asterisks added by MainMenu.complete_usemodule()
         module = "powershell/%s" %(line.strip().rstrip("*"))
 
         if module not in self.mainMenu.modules.modules:
@@ -2566,6 +2569,7 @@ class PythonAgentMenu(cmd.Cmd):
     def do_usemodule(self, line):
         "Use an Empire Python module."
 
+        # Strip asterisks added by MainMenu.complete_usemodule()
         module = "python/%s" %(line.strip().rstrip("*"))
 
         if module not in self.mainMenu.modules.modules:
@@ -3275,6 +3279,7 @@ class ModuleMenu(cmd.Cmd):
     def do_usemodule(self, line):
         "Use an Empire PowerShell module."
 
+        # Strip asterisks added by MainMenu.complete_usemodule()
         module = line.strip().rstrip("*")
 
         if module not in self.mainMenu.modules.modules:

--- a/lib/common/messages.py
+++ b/lib/common/messages.py
@@ -427,7 +427,10 @@ def display_module_search(moduleName, module):
     Displays the name/description of a module for search results.
     """
 
-    print " %s\n" % (helpers.color(moduleName, 'blue'))
+    if module.info['NeedsAdmin']:
+        print " %s*\n" % (helpers.color(moduleName, 'blue'))
+    else:
+        print " %s\n" % (helpers.color(moduleName, 'blue'))
     # width=40, indent=32, indentAll=False,
 
     lines = textwrap.wrap(textwrap.dedent(module.info['Description']).strip(), width=70)

--- a/lib/common/messages.py
+++ b/lib/common/messages.py
@@ -427,6 +427,7 @@ def display_module_search(moduleName, module):
     Displays the name/description of a module for search results.
     """
 
+    # Suffix modules requring elevated context with '*'
     if module.info['NeedsAdmin']:
         print " %s*\n" % (helpers.color(moduleName, 'blue'))
     else:


### PR DESCRIPTION
This pull request adds functionality described in issue #598. Changes in `empire.py` handle suffixing of modules when tab completing as well as stripping the asterisks when module names are passed to various methods.

As stated in issue #598, feel free to reject this if it fails to add value to the project. It has made my life easier when tab completing module names.