### PR TITLE
Invoke-kerberoast bugfix and outputformat changes

### DIFF
--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -469,10 +469,6 @@ Specifies a PowerView.User object (result of Get-NetUser) to request the ticket 
 Either 'John' for John the Ripper style hash formatting, or 'Hashcat' for Hashcat format.
 Defaults to 'John'.
 
-.PARAMETER OutputHashesOnly
-True gives you just the hashes on copy/pastable format. False gives you a formatted list.
-Defaults to True
-
 .EXAMPLE
 
 Get-SPNTicket -SPN "HTTP/web.testlab.local"
@@ -577,7 +573,7 @@ Outputs a custom object containing the SamAccountName, DistinguishedName, Servic
                 if ($OutputFormat -match 'John') {
                     $HashFormat = '$krb5tgs$' + $SamAccountName + ':' + $Hash
                 }
-                else{
+                else {
                     # hashcat output format
                     $HashFormat = '$krb5tgs$23$*SamAccountName: ' + $SamAccountName + ' ServicePrincipalName: ' + $Ticket.ServicePrincipalName + '*$' + $Hash   
                 }
@@ -654,10 +650,6 @@ for connection to the target domain.
 
 Either 'John' for John the Ripper style hash formatting, or 'Hashcat' for Hashcat format.
 Defaults to 'John'.
-
-.PARAMETER OutputHashesOnly
-
-blah
 
 .EXAMPLE
 
@@ -760,7 +752,6 @@ Outputs a custom object containing the SamAccountName, DistinguishedName, Servic
 
         $GetSPNTicketArguments = @{}
         if ($PSBoundParameters['OutputFormat']) { $GetSPNTicketArguments['OutputFormat'] = $OutputFormat }
-        if ($PSBoundParameters['OutputHashesOnly']) { $GetSPNTicketArguments['OutputHashesOnly'] = $OutputHashesOnly }
 
     }
 

--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -469,6 +469,10 @@ Specifies a PowerView.User object (result of Get-NetUser) to request the ticket 
 Either 'John' for John the Ripper style hash formatting, or 'Hashcat' for Hashcat format.
 Defaults to 'John'.
 
+.PARAMETER OutputHashesOnly
+True gives you just the hashes on copy/pastable format. False gives you a formatted list.
+Defaults to True
+
 .EXAMPLE
 
 Get-SPNTicket -SPN "HTTP/web.testlab.local"
@@ -571,17 +575,18 @@ Outputs a custom object containing the SamAccountName, DistinguishedName, Servic
                 $Out | Add-Member Noteproperty 'ServicePrincipalName' $Ticket.ServicePrincipalName
 
                 if ($OutputFormat -match 'John') {
-                    $HashFormat = "`$krb5tgs`$unknown:$Hash"
+                    $HashFormat = '$krb5tgs$' + $SamAccountName + ':' + $Hash
                 }
-                else {
+                else{
                     # hashcat output format
-                    $HashFormat = '$krb5tgs$23$*ID#124_DISTINGUISHED NAME: CN=fakesvc,OU=Service,OU=Accounts,OU=EnterpriseObjects,DC=proddfs,DC=pf,DC=fakedomain,DC=com SPN: E3514235-4B06-11D1-AB04-00C04FC2DCD2-ADAM/NAKCRA04.proddfs.pf.fakedomain.com:50000 *' + $Hash
+                    $HashFormat = '$krb5tgs$23$*SamAccountName: ' + $SamAccountName + ' ServicePrincipalName: ' + $Ticket.ServicePrincipalName + '*$' + $Hash   
                 }
                 $Out | Add-Member Noteproperty 'Hash' $HashFormat
-
                 $Out.PSObject.TypeNames.Insert(0, 'PowerView.SPNTicket')
-
-                Write-Output $Out
+		
+                #Write-Output $Out
+                Write-Output $HashFormat
+                 
                 break
             }
         }
@@ -649,6 +654,10 @@ for connection to the target domain.
 
 Either 'John' for John the Ripper style hash formatting, or 'Hashcat' for Hashcat format.
 Defaults to 'John'.
+
+.PARAMETER OutputHashesOnly
+
+blah
 
 .EXAMPLE
 
@@ -751,6 +760,7 @@ Outputs a custom object containing the SamAccountName, DistinguishedName, Servic
 
         $GetSPNTicketArguments = @{}
         if ($PSBoundParameters['OutputFormat']) { $GetSPNTicketArguments['OutputFormat'] = $OutputFormat }
+        if ($PSBoundParameters['OutputHashesOnly']) { $GetSPNTicketArguments['OutputHashesOnly'] = $OutputHashesOnly }
 
     }
 


### PR DESCRIPTION
The bugfix: On line 587 there is a missing $ after the *.  Without the $, the hashes are accepted by Hashcat but they would never crack. Added the $ after the * fixes the issue and they can crack.  This bug is also present in Will's Invoke-Kerberoast.ps1 gist: https://gist.github.com/HarmJ0y/cc1004307157e372fc5bd3f89e553059

The first improvement is non disruptive. On line 578 I stuffed the ps object properties into $HashFormat rather than using the random "ID#124..." content.  This allows you to see which hash just got cracked in Hashcat without having to search the source of the hashes to match up the data. 

The second improvement is disruptive, but i think better.  I changed the Write-Output line to output just the HashFormat and not the formatted PS object.  So you no longer get a PS object. What you get instead is output that you can directly copy/paste into a file that you send to hashcat without any other modification. 

Maybe I am missing something obvious though.  I know if you use Invoke-Kerberoast.ps1 directly, you can convert the object to csv and that output is usable, but with Empire you don't have that option.  I was going to try and add a new parameter that would allow the user to toggle which output they want, but I don't see how, within Empire, anyone wants the ASCII representation of the fl output with all that white space.

