### PR TITLE
adding M2Crypto library to install.sh

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -108,6 +108,7 @@ else
 	 pip install pyinstaller
 	 pip install zlib_wrapper
 	 pip install netifaces
+	 pip install M2Crypto
          if ! which powershell > /dev/null; then
             wget http://archive.ubuntu.com/ubuntu/pool/main/i/icu/libicu55_55.1-7_amd64.deb
             wget http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u6_amd64.deb


### PR DESCRIPTION
in macOs sierra, "M2Crypto" library is still missing after running the install.sh