### PR TITLE
Invoke-Kerberoast: Print hashes only. Formatting with a text editor is no longer required.

### DIFF
--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -588,7 +588,11 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
                 }
                 $Out | Add-Member Noteproperty 'Hash' $HashFormat
                 $Out.PSObject.TypeNames.Insert(0, 'PowerView.SPNTicket')
-                Write-Output $Out
+                #Prints the PS Object
+                #Write-Output $Out
+
+                #Prints just the hashes
+                Write-Output $HashFormat
             }
         }
     }


### PR DESCRIPTION
Changed the Write-Output line to print just the $HashFormat and not the whole PS object. This way you get output that you can directly copy/paste into a file that you send to hashcat/john without any other modification.