### PR TITLE
Adding the ls_lin modules to support the ls command on linux devices.

### DIFF
--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -19,7 +19,8 @@ import sqlite3
 import os
 import hashlib
 import time
-
+import fnmatch
+import shlex
 
 # Empire imports
 import helpers

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -2619,7 +2619,7 @@ class PythonAgentMenu(cmd.Cmd):
             module_menu.do_execute("")
 
         else:
-            print helpers.color("[!] python/management/osx/ls module not loaded")
+            print helpers.color("[!] python/management/multi/ls_lin module not loaded")
 
     def do_whoami(self, line):
         "Print the currently logged in user"

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -9,7 +9,7 @@ menu loops.
 """
 
 # make version for Empire
-VERSION = "2.1"
+VERSION = "2.0"
 
 from pydispatch import dispatcher
 
@@ -19,7 +19,7 @@ import sqlite3
 import os
 import hashlib
 import time
-import fnmatch
+
 
 # Empire imports
 import helpers
@@ -72,7 +72,7 @@ class MainMenu(cmd.Cmd):
         time.sleep(1)
 
         # pull out some common configuration information
-        (self.isroot, self.installPath, self.ipWhiteList, self.ipBlackList, self.obfuscate, self.obfuscateCommand) = helpers.get_config('rootuser, install_path,ip_whitelist,ip_blacklist,obfuscate,obfuscate_command')
+        (self.isroot, self.installPath, self.ipWhiteList, self.ipBlackList) = helpers.get_config('rootuser, install_path,ip_whitelist,ip_blacklist')
 
         # change the default prompt for the user
         self.prompt = '(Empire) > '
@@ -86,17 +86,16 @@ class MainMenu(cmd.Cmd):
 
         # parse/handle any passed command line arguments
         self.args = args
+        self.handle_args()
+
+        dispatcher.send('[*] Empire starting up...', sender="Empire")
+
         # instantiate the agents, listeners, and stagers objects
         self.agents = agents.Agents(self, args=args)
         self.credentials = credentials.Credentials(self, args=args)
         self.stagers = stagers.Stagers(self, args=args)
         self.modules = modules.Modules(self, args=args)
         self.listeners = listeners.Listeners(self, args=args)
-        self.handle_args()
-
-        dispatcher.send('[*] Empire starting up...', sender="Empire")
-
-        
 
         # print the loading menu
         messages.loading()
@@ -434,8 +433,6 @@ class MainMenu(cmd.Cmd):
 
     def do_usemodule(self, line):
         "Use an Empire module."
-        # Strip asterisks added by MainMenu.complete_usemodule()
-        line = line.rstrip("*")
         if line not in self.modules.modules:
             print helpers.color("[!] Error: invalid module")
         else:
@@ -576,22 +573,8 @@ class MainMenu(cmd.Cmd):
                         print helpers.color("[!] Error opening ip file %s" % (parts[1]))
                 else:
                     self.agents.ipBlackList = helpers.generate_ip_list(",".join(parts[1:]))
-            elif parts[0].lower() == "obfuscate":
-                if parts[1].lower() == "true":
-                    if not helpers.is_powershell_installed():
-                        print helpers.color("[!] PowerShell is not installed and is required to use obfuscation, please install it first.")
-                    else:
-                        self.obfuscate = True
-                        print helpers.color("[*] Obfuscating all future powershell commands run on all agents.")
-                elif parts[1].lower() == "false":
-                    print helpers.color("[*] Future powershell command run on all agents will not be obfuscated.")
-                    self.obfuscate = False
-                else:
-                    print helpers.color("[!] Valid options for obfuscate are 'true' or 'false'")
-            elif parts[0].lower() == "obfuscate_command":
-                self.obfuscateCommand = parts[1]
             else:
-                print helpers.color("[!] Please choose 'ip_whitelist', 'ip_blacklist', 'obfuscate', or 'obfuscate_command'")
+                print helpers.color("[!] Please choose 'ip_whitelist' or 'ip_blacklist'")
 
 
     def do_reset(self, line):
@@ -610,10 +593,6 @@ class MainMenu(cmd.Cmd):
             print self.agents.ipWhiteList
         if line.strip().lower() == "ip_blacklist":
             print self.agents.ipBlackList
-        if line.strip().lower() == "obfuscate":
-            print self.obfuscate
-        if line.strip().lower() == "obfuscate_command":
-            print self.obfuscateCommand
 
 
     def do_load(self, line):
@@ -709,80 +688,17 @@ class MainMenu(cmd.Cmd):
         else:
             print helpers.color("[!] Please enter a valid agent name")
 
-    def do_preobfuscate(self, line):
-        "Preobfuscate PowerShell module_source files"
-        
-        if not helpers.is_powershell_installed():
-            print helpers.color("[!] PowerShell is not installed and is required to use obfuscation, please install it first.")
-            return
-        
-        module = line.strip()
-        obfuscate_all = False
-        obfuscate_confirmation = False
-        reobfuscate = False
-        
-        # Preobfuscate ALL module_source files
-        if module == "" or module == "all":
-            choice = raw_input(helpers.color("[>] Preobfuscate all PowerShell module_source files using obfuscation command: \"" + self.obfuscateCommand + "\"?\nThis may take a substantial amount of time. [y/N] ", "red"))
-            if choice.lower() != "" and choice.lower()[0] == "y":
-                obfuscate_all = True
-                obfuscate_confirmation = True
-                choice = raw_input(helpers.color("[>] Force reobfuscation of previously obfuscated modules? [y/N] ", "red"))
-                if choice.lower() != "" and choice.lower()[0] == "y":
-                    reobfuscate = True
-
-        # Preobfuscate a selected module_source file
-        else:
-            module_source_fullpath = self.installPath + 'data/module_source/' + module
-            if not os.path.isfile(module_source_fullpath):
-                print helpers.color("[!] The module_source file:" + module_source_fullpath + " does not exist.")
-                return
-
-            choice = raw_input(helpers.color("[>] Preobfuscate the module_source file: " + module + " using obfuscation command: \"" + self.obfuscateCommand + "\"? [y/N] ", "red"))
-            if choice.lower() != "" and choice.lower()[0] == "y":
-                obfuscate_confirmation = True
-                choice = raw_input(helpers.color("[>] Force reobfuscation of previously obfuscated modules? [y/N] ", "red"))
-                if choice.lower() != "" and choice.lower()[0] == "y":
-                    reobfuscate = True
-
-        # Perform obfuscation
-        if obfuscate_confirmation:
-            if obfuscate_all:
-                files = [file for file in helpers.get_module_source_files()]
-            else:
-                files = [self.installPath + 'data/module_source/' + module]
-            for file in files:
-                if reobfuscate or not helpers.is_obfuscated(file):
-                    print helpers.color("[*] Obfuscating " + os.path.basename(file) + "...")
-                else:
-                    print helpers.color("[*] " + os.path.basename(file) + " was already obfuscated. Not reobfuscating.")
-                helpers.obfuscate_module(file, self.obfuscateCommand, reobfuscate)
-
 
     def complete_usemodule(self, text, line, begidx, endidx, language=None):
         "Tab-complete an Empire module path."
 
         module_names = self.modules.modules.keys()
-
-        # suffix each module requiring elevated context with '*'
-        for module_name in module_names:
-            try:
-                if self.modules.modules[module_name].info['NeedsAdmin']:
-                    module_names[module_names.index(module_name)] = (module_name+"*")
-            # handle modules without a NeedAdmins info key
-            except KeyError:
-                pass
-
         if language:
             module_names = [ (module_name[len(language)+1:]) for module_name in module_names if module_name.startswith(language)]
 
         mline = line.partition(' ')[2]
-
         offs = len(mline) - len(text)
-
-        module_names = [s[offs:] for s in module_names if s.startswith(mline)]
-
-        return module_names
+        return [s[offs:] for s in module_names if s.startswith(mline)]
 
 
     def complete_reload(self, text, line, begidx, endidx):
@@ -827,7 +743,7 @@ class MainMenu(cmd.Cmd):
     def complete_set(self, text, line, begidx, endidx):
         "Tab-complete a global option."
 
-        options = ["ip_whitelist", "ip_blacklist", "obfuscate", "obfuscate_command"]
+        options = ["ip_whitelist", "ip_blacklist"]
 
         if line.split(' ')[1].lower() in options:
             return helpers.complete_path(text, line, arg=True)
@@ -877,15 +793,6 @@ class MainMenu(cmd.Cmd):
 
         return self.complete_setlist(text, line, begidx, endidx)
 
-    def complete_preobfuscate(self, text, line, begidx, endidx):
-        "Tab-complete an interact command"
-        options = [ (option[len('data/module_source/'):]) for option in helpers.get_module_source_files() ]
-        options.append('all')
-
-        mline = line.partition(' ')[2]
-        offs = len(mline) - len(text)
-        return [s[offs:] for s in options if s.startswith(mline)]
-    
 
 class AgentsMenu(cmd.Cmd):
     """
@@ -1299,8 +1206,7 @@ class AgentsMenu(cmd.Cmd):
     def do_usemodule(self, line):
         "Use an Empire PowerShell module."
 
-        # Strip asterisks added by MainMenu.complete_usemodule()
-        module = line.strip().rstrip("*")
+        module = line.strip()
 
         if module not in self.mainMenu.modules.modules:
             print helpers.color("[!] Error: invalid module")
@@ -1623,23 +1529,6 @@ class PowerShellAgentMenu(cmd.Cmd):
             # update the agent log
             self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to stop job " + str(jobID))
 
-    def do_downloads(self, line):
-        "Return downloads or kill a download job"
-
-        parts = line.split(' ')
-
-        if len(parts) == 1:
-            if parts[0] == '':
-                self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_GETDOWNLOADS")
-                #update the agent log
-                self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to get downloads")
-            else:
-                print helpers.color("[!] Please use for m 'downloads kill DOWNLOAD_ID'")
-        elif len(parts) == 2:
-            jobID = parts[1].strip()
-            self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_STOPDOWNLOAD", jobID)
-            #update the agent log
-            self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to stop download " + str(jobID))
 
     def do_sleep(self, line):
         "Task an agent to 'sleep interval [jitter]'"
@@ -1865,8 +1754,7 @@ class PowerShellAgentMenu(cmd.Cmd):
     def do_usemodule(self, line):
         "Use an Empire PowerShell module."
 
-        # Strip asterisks added by MainMenu.complete_usemodule()
-        module = "powershell/%s" %(line.strip().rstrip("*"))
+        module = "powershell/%s" %(line.strip())
 
         if module not in self.mainMenu.modules.modules:
             print helpers.color("[!] Error: invalid module")
@@ -2663,8 +2551,7 @@ class PythonAgentMenu(cmd.Cmd):
     def do_usemodule(self, line):
         "Use an Empire Python module."
 
-        # Strip asterisks added by MainMenu.complete_usemodule()
-        module = "python/%s" %(line.strip().rstrip("*"))
+        module = "python/%s" %(line.strip())
 
         if module not in self.mainMenu.modules.modules:
             print helpers.color("[!] Error: invalid module")
@@ -2708,6 +2595,24 @@ class PythonAgentMenu(cmd.Cmd):
 
             module.options['Agent']['Value'] = self.mainMenu.agents.get_agent_name_db(self.sessionID)
             module_menu = ModuleMenu(self.mainMenu, 'python/management/osx/ls')
+            msg = "[*] Tasked agent to list directory contents of: "+str(module.options['Path']['Value'])
+            print helpers.color(msg,color="green")
+            self.mainMenu.agents.save_agent_log(self.sessionID, msg)
+            module_menu.do_execute("")
+
+        else:
+            print helpers.color("[!] python/management/osx/ls module not loaded")
+
+    def do_ls_lin(self, line):
+        "List directory contents at the specified path"
+        
+        if self.mainMenu.modules.modules['python/management/multi/linux_ls']:
+            module = self.mainMenu.modules.modules['python/management/multi/linux_ls']
+            if line.strip() != '':
+                module.options['Path']['Value'] = line.strip()
+
+            module.options['Agent']['Value'] = self.mainMenu.agents.get_agent_name_db(self.sessionID)
+            module_menu = ModuleMenu(self.mainMenu, 'python/management/multi/linux_ls')
             msg = "[*] Tasked agent to list directory contents of: "+str(module.options['Path']['Value'])
             print helpers.color(msg,color="green")
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
@@ -2938,10 +2843,6 @@ class ListenersMenu(cmd.Cmd):
                 stager.options['Listener']['Value'] = listenerName
                 stager.options['Language']['Value'] = language
                 stager.options['Base64']['Value'] = "True"
-                if self.mainMenu.obfuscate:
-                    stager.options['Obfuscate']['Value'] = "True"
-                else:
-                    stager.options['Obfuscate']['Value'] = "False"
                 print stager.generate()
             except Exception as e:
                 print helpers.color("[!] Error generating launcher: %s" % (e))
@@ -3377,8 +3278,7 @@ class ModuleMenu(cmd.Cmd):
     def do_usemodule(self, line):
         "Use an Empire PowerShell module."
 
-        # Strip asterisks added by MainMenu.complete_usemodule()
-        module = line.strip().rstrip("*")
+        module = line.strip()
 
         if module not in self.mainMenu.modules.modules:
             print helpers.color("[!] Error: invalid module")
@@ -3404,7 +3304,7 @@ class ModuleMenu(cmd.Cmd):
             self.module.execute()
         else:
             agentName = self.module.options['Agent']['Value']
-            moduleData = self.module.generate(self.mainMenu.obfuscate, self.mainMenu.obfuscateCommand)
+            moduleData = self.module.generate()
 
             if not moduleData or moduleData == "":
                 print helpers.color("[!] Error: module produced an empty script")

--- a/lib/modules/python/management/multi/linux_ls.py
+++ b/lib/modules/python/management/multi/linux_ls.py
@@ -1,0 +1,122 @@
+from lib.common import helpers
+
+
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'linux_ls',
+
+            # list of one or more authors for the module
+            'Author': ['@jarrodcoulter'],
+
+            # more verbose multi-line description of the module
+            'Description': ('List contents of a directory on Linux OS'),
+
+            # True if the module needs to run in the background
+            'Background': False,
+
+            # File extension to save the file as
+            # no need to base64 return data
+            'OutputExtension': None,
+
+            'NeedsAdmin' : False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe': True,
+
+            # the module language
+            'Language' : 'python',
+
+            # the minimum language version needed
+            'MinLanguageVersion' : '2.6',
+
+            # list of any references/other comments
+            'Comments': [
+                'Link:',
+                'Based on the original ls for Mac OS'
+            ]
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent': {
+                # The 'Agent' option is the only one that MUST be in a module
+                'Description'   :   'Agent to run the module.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'Path': {
+                'Description'   :   'Path. Defaults to the current directory. This module is mainly for organization. The alias \'ls_lin\' can be used at the agent menu.',
+                'Required'      :   True,
+                'Value'         :   '.'
+            }
+        }
+
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters
+        #   are passed as an object set to the module and the
+        #   options dictionary is automatically set. This is mostly
+        #   in case options are passed on the command line
+        if params:
+            for param in params:
+                # parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+    def generate(self):
+
+        filePath = self.options['Path']['Value']
+        filePath += '/'
+
+        script = """
+try:
+    import grp
+    import pwd
+    import os
+    import time
+except:
+    print "A required module is missing.."
+
+path = "%s"
+dirlist = os.listdir(path)
+
+directoryListString = "owner/group\\t\\t\\tlast modified\\t\\t\\tsize\\t\\tname\\n"
+
+for item in dirlist:
+    fullpath = os.path.abspath(os.path.join(path,item))
+    st = os.stat(fullpath)
+    uid = st.st_uid
+    gid = st.st_gid
+    name = item 
+    lastModified = str(time.ctime(os.path.getmtime(fullpath)))
+    group = grp.getgrgid(gid)[0]
+    owner = pwd.getpwuid(uid)[0]
+    size = str(os.path.getsize(fullpath))
+    if int(size) > 1024:
+        size = int(size) / 1024
+        size = str(size) + "K"
+    else:
+        size += "B"
+    listString = owner + "/" + group + "\\t\\t" + lastModified + "\\t" + size + "\\t\\t" + name + "\\n"
+    if os.path.isdir(fullpath):
+        listString = "d"+listString
+    else:
+        listString = "-"+listString
+
+    directoryListString += listString
+
+print str(os.getcwd())
+print directoryListString
+""" % filePath
+
+        return script


### PR DESCRIPTION
The python empire agent does not have support for the ls command on the Linux OS, it was developed for the mac OS.  I copied that module and updated it to work on Linux and moved it into the Multi folder as ls_lin.py.  I also updated the empire.py to add the alias and module. It may be a good idea to update the original ls module for mac os to help differentiate between the two.