### PR TITLE
Fixed global name 'ssl' is not defined

### DIFF
--- a/empire
+++ b/empire
@@ -6,7 +6,7 @@ from flask import Flask, request, jsonify, make_response, abort, url_for
 from time import localtime, strftime
 from OpenSSL import SSL
 from Crypto.Random import random
-
+import ssl
 # Empire imports
 from lib.common import empire
 from lib.common import helpers


### PR DESCRIPTION
```python
    certPath = os.path.abspath("./data/")
    context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
    context.load_cert_chain("%s/empire-chain.pem" % (certPath), "%s/empire-priv.key" % (certPath))
    app.run(host='0.0.0.0', port=int(port), ssl_context=context, threaded=True)
```
