### PR TITLE
PowerUp.ps1:2466 - Check SystemPath only

### DIFF
--- a/data/module_source/privesc/PowerUp.ps1
+++ b/data/module_source/privesc/PowerUp.ps1
@@ -2463,7 +2463,7 @@ function Find-PathDLLHijack {
     Param()
 
     # use -LiteralPaths so the spaces in %PATH% folders are not tokenized
-    Get-Item Env:Path | Select-Object -ExpandProperty Value | ForEach-Object { $_.split(';') } | Where-Object {$_ -and ($_ -ne '')} | ForEach-Object {
+     (get-itemproperty "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment").path.split(';') | ForEach-Object {
         $TargetPath = $_
 
         $ModifidablePaths = $TargetPath | Get-ModifiablePath -LiteralPaths | Where-Object {$_ -and ($_ -ne $Null) -and ($_.ModifiablePath -ne $Null) -and ($_.ModifiablePath.Trim() -ne '')}

--- a/data/module_source/privesc/PowerUp.ps1
+++ b/data/module_source/privesc/PowerUp.ps1
@@ -3854,7 +3854,7 @@ function Invoke-AllChecks {
 
     # DLL hijacking
 
-    "`n`n[*] Checking %PATH% for potentially hijackable DLL locations..."
+    "`n`n[*] Checking System %PATH% for potentially hijackable DLL locations..."
     $Results = Find-PathDLLHijack
     $Results | Where-Object {$_} | Foreach-Object {
         $AbuseString = "Write-HijackDll -DllPath '$($_.ModifiablePath)\wlbsctrl.dll'"


### PR DESCRIPTION
The current instantiation of code calls the %PATH% environment variable.  However, since PowerUp is normally run with the permissions of an unprivileged crappy user in order to privesc, the %PATH% variable is returned as a concatanation of the SystemPath and UserPath.  Any exploitable services running as SYSTEM will not call DLLs from the UserPath.  Thus, we need to focus on writable folders in the SystemPath only in order to privesc.  The proposed change pulls the SystemPath value directly from the registry and places it in the same format as the original code.