### PR TITLE
PowerUp.ps1:883 - Remove "C:\" False Positives

### DIFF
--- a/data/module_source/privesc/PowerUp.ps1
+++ b/data/module_source/privesc/PowerUp.ps1
@@ -880,7 +880,7 @@ function Get-ModifiablePath {
                                     # if the path doesn't exist, check if the parent folder allows for modification
                                     try {
                                         $ParentPath = (Split-Path -Path $TempPath -Parent).Trim()
-                                        if($ParentPath -and ($ParentPath -ne '') -and (Test-Path -Path $ParentPath )) {
+                                        if($ParentPath -and ($ParentPath -ne '','C:\') -and (Test-Path -Path $ParentPath )) {
                                             $CandidatePaths += Resolve-Path -Path $ParentPath | Select-Object -ExpandProperty Path
                                         }
                                     }


### PR DESCRIPTION
By default, the C:\ folder has special permissions set that allow unprivileged users to create new folders, but not to create or modify files in C:\ .  This special premission set is misinterpreted by the script as a writable folder in the path, even though it is not.  The proposed change removes results that return C:\ (subfolders within C:\ are still returned if they are modifiable).