### PR TITLE
Fix bad check for ./data/empire.pem

### DIFF
--- a/empire
+++ b/empire
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import sqlite3, argparse, sys, argparse, logging, json, string
 import os, re, time, signal, copy, base64, pickle
@@ -1160,8 +1160,8 @@ def start_restful_api(empireMenu, suppress=False, username=None, password=None, 
         return jsonify({'success': True})
 
 
-    if not os.path.exists('./data/empire.pem'):
-        print "[!] Error: cannot find certificate ./data/empire.pem"
+    if not os.path.exists('./data/empire-chain.pem'):
+        print "[!] Error: cannot find certificate ./data/empire-chain.pem"
         sys.exit()
 
 

--- a/empire
+++ b/empire
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 import sqlite3, argparse, sys, argparse, logging, json, string
 import os, re, time, signal, copy, base64, pickle


### PR DESCRIPTION
Fixes issue #700.

It looks like since `empire.pem` was changed to `empire-chain.pem`, not all references in the code were changed. This fixes that and lets empire startup as normal.