### PR TITLE
added option to expand ps object in order to view domain policy details

### DIFF
--- a/lib/modules/powershell/situational_awareness/network/powerview/get_domain_policy.py
+++ b/lib/modules/powershell/situational_awareness/network/powerview/get_domain_policy.py
@@ -7,7 +7,7 @@ class Module:
         self.info = {
             'Name': 'Get-DomainPolicy',
 
-            'Author': ['@harmj0y'],
+            'Author': ['@harmj0y','@DisK0nn3cT','@OrOneEqualsOne'],
 
             'Description': ('Returns the default domain or DC policy for a given domain or domain controller. Part of PowerView.'),
 
@@ -61,6 +61,11 @@ class Module:
                 'Description'   :   'Switch. Return full subnet objects instead of just object names (the default).',
                 'Required'      :   False,
                 'Value'         :   ''
+            },
+            'ExpandObject' : {
+                'Description'   :   'Expand a specific object from the domain policy. For example \'System Access\', entered without quotes',
+                'Required'      :   False,
+                'Value'         :   ''
             }
         }
 
@@ -94,18 +99,25 @@ class Module:
         # get just the code needed for the specified function
         script = helpers.generate_dynamic_powershell_script(moduleCode, moduleName)
 
-        script += moduleName + " "
-
+        pscript = ""
+        expand = False
+        value_to_expand = ""
         for option,values in self.options.iteritems():
-            if option.lower() != "agent":
+            if option.lower() != "agent" and option.lower() != "expandobject":
                 if values['Value'] and values['Value'] != '':
                     if values['Value'].lower() == "true":
                         # if we're just adding a switch
-                        script += " -" + str(option)
+                        pscript += " -" + str(option)
                     else:
-                        script += " -" + str(option) + " " + str(values['Value']) 
+                        pscript += " -" + str(option) + " " + str(values['Value']) 
+            if option.lower() == "expandobject" and values['Value']:
+                expand = True
+                value_to_expand += values['Value']
 
-        script += ' | fl | Out-String | %{$_ + \"`n\"};"`n'+str(moduleName)+' completed!"'
+        if expand: 
+            script += "(" + moduleName + " " + pscript + ")." + "'" + value_to_expand + "'" + ' | fl | Out-String | %{$_ + \"`n\"};"`n'+str(moduleName)+' completed!"'
+        else:
+            script += moduleName + " " + pscript + ' | fl | Out-String | %{$_ + \"`n\"};"`n'+str(moduleName)+' completed! Use ExpandObject option to expand one of the objects above such as \'System Access\'"'
         if obfuscate:
             script = helpers.obfuscate(psScript=script, obfuscationCommand=obfuscationCommand)
         return script


### PR DESCRIPTION
The output from this module looked like this and wasn't very helpful:

Name  : System Access
Value : {PasswordComplexity, MaximumPasswordAge, MinimumPasswordLength, ForceLog
        offWhenHourExpire...}

Name  : Version
Value : {signature, Revision}

Name  : Kerberos Policy
Value : {TicketValidateClient, MaxTicketAge, MaxRenewAge, MaxClockSkew...}

Name  : Unicode
Value : {Unicode}

Name  : Registry Values
Value : {MACHINE\System\CurrentControlSet\Control\Lsa\NoLMHash}

We (@DisK0nn3cT and I) added an option called "ExpandObject" where you could make the output show the details contained in the powershell object. For example:

set ExpandObject System Access

Gives the following output:

Name  : PasswordComplexity
Value : {1}

Name  : MaximumPasswordAge
Value : {42}

Name  : MinimumPasswordLength
Value : {7}

Name  : ForceLogoffWhenHourExpire
Value : {0}

Name  : LSAAnonymousNameLookup
Value : {0}

Name  : LockoutBadCount
Value : {0}

Name  : PasswordHistorySize
Value : {24}

Name  : MinimumPasswordAge
Value : {1}

Name  : ClearTextPassword
Value : {0}

Name  : RequireLogonToChangePassword
Value : {0}
