### PR TITLE
Modified the PowerShell keylogger to write to local file instead of stdout

### DIFF
--- a/lib/common/agents.py
+++ b/lib/common/agents.py
@@ -1457,9 +1457,16 @@ class Agents:
                 self.process_agent_packet(sessionID, responseName, taskID, data)
                 results = True
 
+            conn = self.get_db_connection()
+            cur = conn.cursor()      
+            data = cur.execute("SELECT data FROM taskings WHERE agent=? AND id=?", [sessionID,taskID]).fetchone()[0]
+	    cur.close()
+	    theSender="Agents"
+	    if data.startswith("function Get-Keystrokes"):
+		theSender += "PsKeyLogger"
             if results:
                 # signal that this agent returned results
-                dispatcher.send("[*] Agent %s returned results." % (sessionID), sender='Agents')
+                dispatcher.send("[*] Agent %s returned results." % (sessionID), sender=theSender)
 
             # return a 200/valid
             return 'VALID'

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -1465,7 +1465,6 @@ class PowerShellAgentMenu(cmd.Cmd):
         """
         Handle agent event signals.
         """
-
         if '[!] Agent' in signal and 'exiting' in signal:
             pass
 
@@ -1476,7 +1475,11 @@ class PowerShellAgentMenu(cmd.Cmd):
             # while we are interacting with it
             results = self.mainMenu.agents.get_agent_results_db(self.sessionID)
             if results:
-                print "\n" + results
+		if sender == "AgentsPsKeyLogger" and "Job started:" not in results:
+		    with open("%s/downloads/%s/keystrokes.txt" % (self.mainMenu.installPath,self.sessionID),"a+") as f:
+		        f.write(results)
+		else:   
+                    print "\n" + results
 
         elif "[+] Part of file" in signal and "saved" in signal:
             if (str(self.sessionID) in signal) or (str(name) in signal):

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -1482,7 +1482,8 @@ class PowerShellAgentMenu(cmd.Cmd):
                         dispatcher.send("[!] WARNING: agent %s attempted skywalker exploit!" % (self.sessionID), sender='Agents')
                  	return
 		    with open(savePath,"a+") as f:
-		        f.write(results)
+			new_results = results.replace("\r\n","").replace("[SpaceBar]", "").replace('\b', '').replace("[Shift]", "").replace("[Enter]\r","\r\n")
+		        f.write(new_results)
 		else:
                    print "\n" + results
 

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -1475,11 +1475,16 @@ class PowerShellAgentMenu(cmd.Cmd):
             # while we are interacting with it
             results = self.mainMenu.agents.get_agent_results_db(self.sessionID)
             if results:
-		if sender == "AgentsPsKeyLogger" and "Job started:" not in results:
-		    with open("%s/downloads/%s/keystrokes.txt" % (self.mainMenu.installPath,self.sessionID),"a+") as f:
+		if sender == "AgentsPsKeyLogger" and ("Job started:" not in results) and ("killed." not in results):
+            	    safePath = os.path.abspath("%sdownloads/" % self.mainMenu.installPath)
+		    savePath = "%sdownloads/%s/keystrokes.txt" % (self.mainMenu.installPath,self.sessionID)
+		    if not os.path.abspath(savePath).startswith(safePath):
+                        dispatcher.send("[!] WARNING: agent %s attempted skywalker exploit!" % (self.sessionID), sender='Agents')
+                 	return
+		    with open(savePath,"a+") as f:
 		        f.write(results)
-		else:   
-                    print "\n" + results
+		else:
+                   print "\n" + results
 
         elif "[+] Part of file" in signal and "saved" in signal:
             if (str(self.sessionID) in signal) or (str(name) in signal):

--- a/lib/modules/powershell/collection/keylogger.py
+++ b/lib/modules/powershell/collection/keylogger.py
@@ -9,7 +9,7 @@ class Module:
 
             'Author': ['@obscuresec', '@mattifestation', '@harmj0y'],
 
-            'Description': ('Logs keys pressed, time and the active window (when changed).'),
+            'Description': ('Logs keys pressed, time and the active window (when changed) to the keystrokes.txt file. This file is located in the agents downloads directory Empire/downloads/<AgentName>/keystrokes.txt.'),
 
             'Background' : True,
 


### PR DESCRIPTION
Having the logged keystrokes spewed onto the screen while trying to use the same agent for other things is messy. This changes the PowerShell keystroke logger to log keys to Empire/downloads/AGENTNAME/keystrokes.txt instead. This keeps all the keystrokes in one place and you can use "tail -f keystrokes.txt" to watch the keystrokes in real time.