### PR TITLE
Added option to listen on a different port for http/https listeners 

### DIFF
--- a/lib/common/messages.py
+++ b/lib/common/messages.py
@@ -237,6 +237,8 @@ def display_active_listeners(listeners):
             moduleName = listener['moduleName']
             if 'Host' in listener['options']:
                 host = listener['options']['Host']['Value']
+                if 'ListenPort' in listener['options'] and listener['options']['ListenPort']['Value'] != '':
+                    host += ' (%s)' % listener['options']['ListenPort']['Value']
             else:
                 host = ''
 
@@ -249,7 +251,7 @@ def display_active_listeners(listeners):
                 defaultJitter = listener['options']['DefaultJitter']['Value']
             else:
                 defaultJitter = ''
-            
+
             if defaultDelay == 'n/a':
                 connectInterval = 'n/a'
             else:

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -960,8 +960,8 @@ def send_message(packets=None):
                 app.run(host=bindIP, port=int(listenport), threaded=True)
 
         except Exception as e:
-            print helpers.color("[!] Listener startup on port %s failed: %s " % (port, e))
-            dispatcher.send("[!] Listener startup on port %s failed: %s " % (port, e), sender='listeners/http')
+            print helpers.color("[!] Listener startup on port %s failed: %s " % (listenport, e))
+            dispatcher.send("[!] Listener startup on port %s failed: %s " % (listenport, e), sender='listeners/http')
 
 
     def start(self, name=''):

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -53,9 +53,14 @@ class Listener:
                 'Value'         :   '0.0.0.0'
             },
             'Port' : {
-                'Description'   :   'Port for the listener.',
+                'Description'   :   'Port for agents to connect on.',
                 'Required'      :   True,
                 'Value'         :   80
+            },
+            'ListenPort' : {
+                'Description'   :   'Optional different port for listening on the control server',
+                'Required'      :   False,
+                'Value'         :   ""
             },
             'Launcher' : {
                 'Description'   :   'Launcher string.',
@@ -942,13 +947,17 @@ def send_message(packets=None):
         try:
             certPath = listenerOptions['CertPath']['Value']
             host = listenerOptions['Host']['Value']
+            if listenerOptions['ListenPort']['Value'] == '':
+                listenport = port
+            else:
+                listenport = listenerOptions['ListenPort']['Value']
             if certPath.strip() != '' and host.startswith('https'):
                 certPath = os.path.abspath(certPath)
                 context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
                 context.load_cert_chain("%s/empire-chain.pem" % (certPath), "%s/empire-priv.key"  % (certPath))
-                app.run(host=bindIP, port=int(port), threaded=True, ssl_context=context)
+                app.run(host=bindIP, port=int(listenport), threaded=True, ssl_context=context)
             else:
-                app.run(host=bindIP, port=int(port), threaded=True)
+                app.run(host=bindIP, port=int(listenport), threaded=True)
 
         except Exception as e:
             print helpers.color("[!] Listener startup on port %s failed: %s " % (port, e))

--- a/lib/listeners/http_com.py
+++ b/lib/listeners/http_com.py
@@ -628,8 +628,8 @@ class Listener:
                 app.run(host=bindIP, port=int(listenport), threaded=True)
 
         except Exception as e:
-            print helpers.color("[!] Listener startup on port %s failed: %s " % (port, e))
-            dispatcher.send("[!] Listener startup on port %s failed: %s " % (port, e), sender='listeners/http_com')
+            print helpers.color("[!] Listener startup on port %s failed: %s " % (listenport, e))
+            dispatcher.send("[!] Listener startup on port %s failed: %s " % (listenport, e), sender='listeners/http_com')
 
 
     def start(self, name=''):


### PR DESCRIPTION
When having a red team C2 infrastructure it can be useful to have multiple channels to the same server via for example proxy domains.
This pull request adds the option to specify a port that the listener will bind on instead of the current behaviour, in which the listening port is always equal to the port that the agent will connect to. 
With this it is possible to have a proxy forward for example requests for `my-domain-a.com:443` to the Empire listener on port 4000 and requests for `my-domain-b.com:443` to Empire on port 4001.

```
(Empire) > listeners

[*] Active listeners:

  Name              Module          Host                                 Delay/Jitter   KillDate
  ----              ------          ----                                 ------------   --------
  http11            http            http://my-domain-b.com:443 (8002)    5/0.0                      
  http1             http            http://my-domain-a.com:443 (8001)    5/0.0                      

```