### PR TITLE
Slack Integration - Notification for new Agents

### DIFF
--- a/lib/common/agents.py
+++ b/lib/common/agents.py
@@ -60,6 +60,7 @@ import os
 import json
 import string
 import threading
+import urllib, urllib2
 from pydispatch import dispatcher
 from zlib_wrapper import compress
 from zlib_wrapper import decompress
@@ -1324,7 +1325,17 @@ class Agents:
             # signal everyone that this agent is now active
             dispatcher.send("[+] Initial agent %s from %s now active" % (sessionID, clientIP), sender='Agents')
             output = "[+] Agent %s now active:\n" % (sessionID)
-
+	    slackToken = listenerOptions['SlackToken']['Value']
+	    slackChannel = listenerOptions['SlackChannel']['Value']
+	    slackMessage = ":biohazard: NEW AGENT :biohazard:\r\n```Machine Name: %s\r\nInternal IP: %s\r\nExternal IP: %s\r\nUser: %s\r\nOS Version: %s\r\nAgent ID: %s```" % (hostname,internal_ip,external_ip,username,os_details,sessionID)
+            dispatcher.send("[+] Checking for Slack token: %s" % slackToken, sender='Agents')
+	    if slackToken != "":
+		# send slack notification
+                url = "https://slack.com/api/chat.postMessage"
+		data = urllib.urlencode({'token': slackToken, 'channel':slackChannel, 'text':slackMessage})
+ 		req = urllib2.Request(url, data)
+ 		resp = urllib2.urlopen(req)
+	    
             # save the initial sysinfo information in the agent log
             agent = self.mainMenu.agents.get_agent_db(sessionID)
             output = messages.display_agent(agent, returnAsString=True)

--- a/lib/common/agents.py
+++ b/lib/common/agents.py
@@ -1321,14 +1321,15 @@ class Agents:
             # update the agent with this new information
             self.mainMenu.agents.update_agent_sysinfo_db(sessionID, listener=listenerName, internal_ip=internal_ip, username=username, hostname=hostname, os_details=os_details, high_integrity=high_integrity, process_name=process_name, process_id=process_id, language_version=language_version, language=language)
 
-            # signal everyone that this agent is now active
+            # signal to Slack that this agent is now active
             output = "[+] Agent %s now active:\n" % (sessionID)
 	    slackToken = listenerOptions['SlackToken']['Value']
 	    slackChannel = listenerOptions['SlackChannel']['Value']
 	    if slackToken != "":
-		# send slack notification
 	    	slackText = ":biohazard: NEW AGENT :biohazard:\r\n```Machine Name: %s\r\nInternal IP: %s\r\nExternal IP: %s\r\nUser: %s\r\nOS Version: %s\r\nAgent ID: %s```" % (hostname,internal_ip,external_ip,username,os_details,sessionID)
                 helpers.slackMessage(slackToken,slackChannel,slackText)
+            
+	    # signal everyone that this agent is now active
             dispatcher.send("[+] Initial agent %s from %s now active (Slack)" % (sessionID, clientIP), sender='Agents')
 	    
             # save the initial sysinfo information in the agent log

--- a/lib/common/agents.py
+++ b/lib/common/agents.py
@@ -60,7 +60,6 @@ import os
 import json
 import string
 import threading
-import urllib, urllib2
 from pydispatch import dispatcher
 from zlib_wrapper import compress
 from zlib_wrapper import decompress
@@ -1323,18 +1322,14 @@ class Agents:
             self.mainMenu.agents.update_agent_sysinfo_db(sessionID, listener=listenerName, internal_ip=internal_ip, username=username, hostname=hostname, os_details=os_details, high_integrity=high_integrity, process_name=process_name, process_id=process_id, language_version=language_version, language=language)
 
             # signal everyone that this agent is now active
-            dispatcher.send("[+] Initial agent %s from %s now active" % (sessionID, clientIP), sender='Agents')
             output = "[+] Agent %s now active:\n" % (sessionID)
 	    slackToken = listenerOptions['SlackToken']['Value']
 	    slackChannel = listenerOptions['SlackChannel']['Value']
-	    slackMessage = ":biohazard: NEW AGENT :biohazard:\r\n```Machine Name: %s\r\nInternal IP: %s\r\nExternal IP: %s\r\nUser: %s\r\nOS Version: %s\r\nAgent ID: %s```" % (hostname,internal_ip,external_ip,username,os_details,sessionID)
-            dispatcher.send("[+] Checking for Slack token: %s" % slackToken, sender='Agents')
 	    if slackToken != "":
 		# send slack notification
-                url = "https://slack.com/api/chat.postMessage"
-		data = urllib.urlencode({'token': slackToken, 'channel':slackChannel, 'text':slackMessage})
- 		req = urllib2.Request(url, data)
- 		resp = urllib2.urlopen(req)
+	    	slackText = ":biohazard: NEW AGENT :biohazard:\r\n```Machine Name: %s\r\nInternal IP: %s\r\nExternal IP: %s\r\nUser: %s\r\nOS Version: %s\r\nAgent ID: %s```" % (hostname,internal_ip,external_ip,username,os_details,sessionID)
+                helpers.slackMessage(slackToken,slackChannel,slackText)
+            dispatcher.send("[+] Initial agent %s from %s now active (Slack)" % (sessionID, clientIP), sender='Agents')
 	    
             # save the initial sysinfo information in the agent log
             agent = self.mainMenu.agents.get_agent_db(sessionID)

--- a/lib/common/helpers.py
+++ b/lib/common/helpers.py
@@ -35,6 +35,7 @@ Includes:
     complete_path() - helper to tab-complete file paths
     dict_factory() - helper that returns the SQLite query results as a dictionary
     KThread() - a subclass of threading.Thread, with a kill() method
+    slackMessage() - send notifications to the Slack API
 
 """
 
@@ -54,6 +55,7 @@ from time import localtime, strftime
 from Crypto.Random import random
 import subprocess
 import fnmatch
+import urllib, urllib2
 
 ###############################################################
 #
@@ -878,3 +880,9 @@ class KThread(threading.Thread):
 
     def kill(self):
         self.killed = True
+
+def slackMessage(slackToken, slackChannel, slackText):
+	url = "https://slack.com/api/chat.postMessage"
+	data = urllib.urlencode({'token': slackToken, 'channel':slackChannel, 'text':slackText})
+ 	req = urllib2.Request(url, data)
+ 	resp = urllib2.urlopen(req)

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -126,6 +126,16 @@ class Listener:
                 'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
+            },
+            'SlackToken' : {
+                'Description'   :   'Your SlackBot API token to communicate with your Slack instance.',
+                'Required'      :   False,
+                'Value'         :   ''
+            },
+            'SlackChannel' : {
+                'Description'   :   'The Slack channel or DM that notifications will be sent to.',
+                'Required'      :   False,
+                'Value'         :   '#general'
             }
         }
 


### PR DESCRIPTION
Integrates notifications to be sent to a Slack channel via the Slack API by using the new helper slackMessage() function. When an agent calls home for the first time a message will be sent to the slack channel setup in the listener settings. 

The required parameters are
 - SlackToken: a token generated for your specific slack instance
 - SlackChannel: a channel or user to send notifications to
 - SlackText: the message to be sent

Screenshots:

![image](https://user-images.githubusercontent.com/26440487/31159928-d49df73e-a889-11e7-8897-1a2ccf954ccd.png)

![image](https://user-images.githubusercontent.com/26440487/31159995-49d5a04c-a88a-11e7-9205-ceb252c28b49.png)
