### PR TITLE
Fix #749 - Add check for 'Agent' in self.module.options

### DIFF
--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -3394,7 +3394,10 @@ class ModuleMenu(cmd.Cmd):
         if module not in self.mainMenu.modules.modules:
             print helpers.color("[!] Error: invalid module")
         else:
-            module_menu = ModuleMenu(self.mainMenu, line, agent=self.module.options['Agent']['Value'])
+            _agent = ''
+            if 'Agent' in self.module.options:
+                _agent = self.module.options['Agent']['Value']
+            module_menu = ModuleMenu(self.mainMenu, line, agent=_agent)
             module_menu.cmdloop()
 
 

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -3397,6 +3397,8 @@ class ModuleMenu(cmd.Cmd):
             _agent = ''
             if 'Agent' in self.module.options:
                 _agent = self.module.options['Agent']['Value']
+	    
+	    line = line.strip("*")
             module_menu = ModuleMenu(self.mainMenu, line, agent=_agent)
             module_menu.cmdloop()
 


### PR DESCRIPTION
When attempting to switch Modules it will try to set the current Agent for the
new module that will be used. However, this fails when switching from
`external/generate_agent.py` because it does not have this option within the
`self.module.options`.

Therefore, I changed it to check if the `Key` exists within `self.module.options`
and if it does not exist it will be set to `''`.