### PR TITLE
Code cleanup from Empyre merge 

### DIFF
--- a/lib/modules/python/management/multi/spawn.py
+++ b/lib/modules/python/management/multi/spawn.py
@@ -14,7 +14,7 @@ class Module:
             'Author': ['@harmj0y'],
 
             # more verbose multi-line description of the module
-            'Description': ('Spawns a new EmPyre agent.'),
+            'Description': ('Spawns a new Empire agent.'),
 
             # True if the module needs to run in the background
             'Background' : False,

--- a/lib/modules/python/persistence/osx/CreateHijacker.py
+++ b/lib/modules/python/persistence/osx/CreateHijacker.py
@@ -12,7 +12,7 @@ class Module:
             'Author': ['@patrickwardle,@xorrior'],
 
             # more verbose multi-line description of the module
-            'Description': ('Configures and EmPyre dylib for use in a Dylib hijack, given the path to a legitimate dylib of a vulnerable application. The architecture of the dylib must match the target application. The configured dylib will be copied local to the hijackerPath'),
+            'Description': ('Configures and Empire dylib for use in a Dylib hijack, given the path to a legitimate dylib of a vulnerable application. The architecture of the dylib must match the target application. The configured dylib will be copied local to the hijackerPath'),
 
             # True if the module needs to run in the background
             'Background' : False,

--- a/lib/modules/python/persistence/osx/RemoveDaemon.py
+++ b/lib/modules/python/persistence/osx/RemoveDaemon.py
@@ -13,7 +13,7 @@ class Module:
             'Author': ['@xorrior'],
 
             # more verbose multi-line description of the module
-            'Description': ('Remove an EmPyre Launch Daemon.'),
+            'Description': ('Remove an Empire Launch Daemon.'),
 
             # True if the module needs to run in the background
             'Background' : False,

--- a/lib/modules/python/persistence/osx/launchdaemonexecutable.py
+++ b/lib/modules/python/persistence/osx/launchdaemonexecutable.py
@@ -12,7 +12,7 @@ class Module:
             'Author': ['@xorrior'],
 
             # more verbose multi-line description of the module
-            'Description': ('Installs an EmPyre launchDaemon.'),
+            'Description': ('Installs an Empire launchDaemon.'),
 
             # True if the module needs to run in the background
             'Background' : False,
@@ -67,7 +67,7 @@ class Module:
                 'Value'         :   'com.proxy.initialize'
             },
             'DaemonLocation' : {
-                'Description'   :   'The full path of where the EmPyre launch daemon should be located.',
+                'Description'   :   'The full path of where the Empire launch daemon should be located.',
                 'Required'      :   True,
                 'Value'         :   ''
             }
@@ -163,7 +163,7 @@ process = subprocess.Popen('launchctl load /Library/LaunchDaemons/%s', stdout=su
 process.communicate()
 
 print "\\n[+] Persistence has been installed: /Library/LaunchDaemons/%s"
-print "\\n[+] EmPyre daemon has been written to %s"
+print "\\n[+] Empire daemon has been written to %s"
 
 """ % (encBytes,plistSettings, programname, plistfilename, plistfilename, plistfilename, plistfilename, plistfilename, plistfilename, plistfilename, plistfilename, programname)
 

--- a/lib/modules/python/persistence/osx/loginhook.py
+++ b/lib/modules/python/persistence/osx/loginhook.py
@@ -11,7 +11,7 @@ class Module:
             'Author': ['@Killswitch-GUI'],
 
             # more verbose multi-line description of the module
-            'Description': ('Installs EmPyre agent via LoginHook.'),
+            'Description': ('Installs Empire agent via LoginHook.'),
 
             # True if the module needs to run in the background
             'Background' : False,

--- a/lib/modules/python/privesc/multi/sudo_spawn.py
+++ b/lib/modules/python/privesc/multi/sudo_spawn.py
@@ -14,7 +14,7 @@ class Module:
             'Author': ['@harmj0y'],
 
             # more verbose multi-line description of the module
-            'Description': ('Spawns a new EmPyre agent using sudo.'),
+            'Description': ('Spawns a new Empire agent using sudo.'),
 
             # True if the module needs to run in the background
             'Background' : False,

--- a/lib/modules/python/privesc/osx/piggyback.py
+++ b/lib/modules/python/privesc/osx/piggyback.py
@@ -14,7 +14,7 @@ class Module:
             'Author': ['@n00py'],
 
             # more verbose multi-line description of the module
-            'Description': ('Spawns a new EmPyre agent using an existing sudo session.  This works up until El Capitan.'),
+            'Description': ('Spawns a new Empire agent using an existing sudo session.  This works up until El Capitan.'),
 
             # True if the module needs to run in the background
             'Background' : False,

--- a/lib/stagers/multi/bash.py
+++ b/lib/stagers/multi/bash.py
@@ -10,7 +10,7 @@ class Stager:
 
             'Author': ['@harmj0y'],
 
-            'Description': ('Generates self-deleting Bash script to execute the EmPyre stage0 launcher.'),
+            'Description': ('Generates self-deleting Bash script to execute the Empire stage0 launcher.'),
 
             'Comments': [
                 ''

--- a/lib/stagers/multi/pyinstaller.py
+++ b/lib/stagers/multi/pyinstaller.py
@@ -8,10 +8,10 @@ Install steps...
 -- try: apt-get -y install python-pip && pip install pyinstaller
 
 - copy into stagers directory
--- ./EmPyre/lib/stagers/
+-- ./Empire/lib/stagers/
 
-- kick off the emPyre agent on a remote target
--- /tmp/emPyre &
+- kick off the empire agent on a remote target
+-- /tmp/empire &
 
 @TweekFawkes
 
@@ -26,7 +26,7 @@ class Stager:
 
 			'Author': ['@TweekFawkes'],
 
-			'Description': ('Generates an ELF binary payload launcher for EmPyre using pyInstaller.'),
+			'Description': ('Generates an ELF binary payload launcher for Empire using pyInstaller.'),
 
 			'Comments': [
 				'Needs to have pyInstaller setup on the system you are creating the stager on. For debian based operatins systems try the following command: apt-get -y install python-pip && pip install pyinstaller'
@@ -50,7 +50,7 @@ class Stager:
 			'BinaryFile' : {
 				'Description'   :   'File to output launcher to.',
 				'Required'      :   True,
-				'Value'         :   '/tmp/emPyre'
+				'Value'         :   '/tmp/empire'
 			},
       'SafeChecks' : {
           'Description'   :   'Switch. Checks for LittleSnitch or a SandBox, exit the staging process if true. Defaults to True.',

--- a/lib/stagers/osx/applescript.py
+++ b/lib/stagers/osx/applescript.py
@@ -10,7 +10,7 @@ class Stager:
 
             'Author': ['@harmj0y'],
 
-            'Description': ('Generates AppleScript to execute the EmPyre stage0 launcher.'),
+            'Description': ('Generates AppleScript to execute the Empire stage0 launcher.'),
 
             'Comments': [
                 ''

--- a/lib/stagers/osx/application.py
+++ b/lib/stagers/osx/application.py
@@ -10,7 +10,7 @@ class Stager:
 
             'Author': ['@xorrior'],
 
-            'Description': ('Generates an EmPyre Application.'),
+            'Description': ('Generates an Empire Application.'),
 
             'Comments': [
                 ''
@@ -42,7 +42,7 @@ class Stager:
                 'Value'         :   ''
             },
             'OutFile' : {
-                'Description'   :   'path to output EmPyre application. The application will be saved to a zip file.',
+                'Description'   :   'path to output Empire application. The application will be saved to a zip file.',
                 'Required'      :   True,
                 'Value'         :   '/tmp/out.zip'
             },

--- a/lib/stagers/osx/ducky.py
+++ b/lib/stagers/osx/ducky.py
@@ -9,7 +9,7 @@ class Stager:
 
             'Author': ['@xorrior'],
 
-            'Description': ('Generates a ducky script that runs a one-liner stage0 launcher for EmPyre.'),
+            'Description': ('Generates a ducky script that runs a one-liner stage0 launcher for Empire.'),
 
             'Comments': [
                 ''

--- a/lib/stagers/osx/launcher.py
+++ b/lib/stagers/osx/launcher.py
@@ -10,7 +10,7 @@ class Stager:
 
             'Author': ['@harmj0y'],
 
-            'Description': ('Generates a one-liner stage0 launcher for EmPyre.'),
+            'Description': ('Generates a one-liner stage0 launcher for Empire.'),
 
             'Comments': [
                 ''

--- a/lib/stagers/osx/pkg.py
+++ b/lib/stagers/osx/pkg.py
@@ -9,7 +9,7 @@ class Stager:
 
             'Author': ['@xorrior'],
 
-            'Description': ('Generates a pkg installer. The installer will copy a custom (empty) application to the /Applications folder. The postinstall script will execute an EmPyre launcher.'),
+            'Description': ('Generates a pkg installer. The installer will copy a custom (empty) application to the /Applications folder. The postinstall script will execute an Empire launcher.'),
 
             'Comments': [
                 ''

--- a/lib/stagers/osx/safari_launcher.py
+++ b/lib/stagers/osx/safari_launcher.py
@@ -10,7 +10,7 @@ class Stager:
 
             'Author': ['@424f424f'],
 
-            'Description': ('Generates an HTML payload launcher for EmPyre.'),
+            'Description': ('Generates an HTML payload launcher for Empire.'),
 
             'Comments': [
                 'https://www.exploit-db.com/exploits/38535/'

--- a/lib/stagers/osx/teensy.py
+++ b/lib/stagers/osx/teensy.py
@@ -10,7 +10,7 @@ class Stager:
 
             'Author': ['Matt @matterpreter Hand'],
 
-            'Description': ('Generates a Teensy script that runs a one-liner stage0 launcher for EmPyre.'),
+            'Description': ('Generates a Teensy script that runs a one-liner stage0 launcher for Empire.'),
 
             'Comments': [
                 ''
@@ -116,7 +116,7 @@ class Stager:
             teensyCode += "    Keyboard.send_now();\n"
             teensyCode += "    clearKeys();\n"
             teensyCode += "}\n\n"
-            teensyCode += "void empyre(void) {\n"
+            teensyCode += "void empire(void) {\n"
             teensyCode += "    delay(500);\n"
             teensyCode += "    mac_minWindows();\n"
             teensyCode += "    mac_minWindows();\n"
@@ -132,7 +132,7 @@ class Stager:
             teensyCode += "    Keyboard.println(\"exit\");\n"
             teensyCode += "}\n\n"
             teensyCode += "void setup(void) {\n"
-            teensyCode += "    empyre();\n"
+            teensyCode += "    empire();\n"
             teensyCode += "}\n\n"
             teensyCode += "void loop() {}"
 


### PR DESCRIPTION
This PR includes some tidying of the use of the term Empyre.  It is left in the Readme and changelogs for historical purposes.  Most of the changes are informational or comments.  A few of the changes rename functions or file locations.  Those changes seem to be contained within the following files:

```
/lib/stagers/multi/pyinstaller.py
/lib/stagers/osx/teensy.py
```