### PR TITLE
Swap out PyCrypto for Cryptography

### DIFF
--- a/empire
+++ b/empire
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
 import sqlite3, argparse, sys, argparse, logging, json, string
-import os, re, time, signal, copy, base64, pickle
+import os, re, time, signal, copy, base64, pickle, random
 from flask import Flask, request, jsonify, make_response, abort, url_for
 from time import localtime, strftime, sleep
 from OpenSSL import SSL
-from Crypto.Random import random
 import ssl
 # Empire imports
 from lib.common import empire

--- a/lib/common/encryption.py
+++ b/lib/common/encryption.py
@@ -8,12 +8,12 @@ Includes:
     depad()                     -   Performs PKCS#7 depadding
     rsa_xml_to_key()            -   parses a PowerShell RSA xml import and builds a M2Crypto object
     rsa_encrypt()               -   encrypts data using the M2Crypto crypto object
-    aes_encrypt()               -   encrypts data using a pyCrypto AES object
-    aes_encrypt_then_hmac()     -   encrypts and SHA256 HMACs data using a pyCrypto AES object
-    aes_decrypt()               -   decrypts data using a pyCrypto AES object
+    aes_encrypt()               -   encrypts data using a Cryptography AES object
+    aes_encrypt_then_hmac()     -   encrypts and SHA256 HMACs data using a Cryptography AES object
+    aes_decrypt()               -   decrypts data using a Cryptography AES object
     verify_hmac()               -   verifies a SHA256 HMAC for a data blob
     aes_decrypt_and_verify()    -   AES decrypts data if the HMAC is validated
-    generate_aes_key()          -   generates a ranodm AES key using pyCrypto's Random functionality
+    generate_aes_key()          -   generates a ranodm AES key using the OS' Random functionality
     rc4()                       -   encrypt/decrypt a data blob using an RC4 key
     DiffieHellman()             -   Mark Loiseau's DiffieHellman implementation, see ./data/licenses/ for license info
 

--- a/lib/common/helpers.py
+++ b/lib/common/helpers.py
@@ -50,8 +50,8 @@ import iptools
 import threading
 import pickle
 import netifaces
+import random
 from time import localtime, strftime
-from Crypto.Random import random
 import subprocess
 import fnmatch
 

--- a/lib/common/packets.py
+++ b/lib/common/packets.py
@@ -64,7 +64,6 @@ import base64
 import os
 import hashlib
 import hmac
-from Crypto import Random
 from pydispatch import dispatcher
 
 # Empire imports
@@ -331,8 +330,7 @@ def build_routing_packet(stagingKey, sessionID, language, meta="NONE", additiona
     #   B == 1 byte unsigned char, H == 2 byte unsigned short, L == 4 byte unsigned long
     data = sessionID + struct.pack("=BBHL", LANGUAGE.get(language.upper(), 0), META.get(meta.upper(), 0), ADDITIONAL.get(additional.upper(), 0), len(encData))
 
-    # RC4IV = os.urandom(4)
-    RC4IV = Random.new().read(4)
+    RC4IV = os.urandom(4)
     stagingKey = str(stagingKey)
     key = RC4IV + stagingKey
     rc4EncData = encryption.rc4(key, data)

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -21,7 +21,6 @@ if lsb_release -d | grep -q "Fedora"; then
 	dnf install -y make g++ python-devel m2crypto python-m2ext swig python-iptools python3-iptools libxml2-devel default-jdk openssl-devel libssl1.0.0 libssl-dev
 	pip install --upgrade urllib3
 	pip install setuptools
-	pip install pycrypto
 	pip install cryptography
 	pip install iptools
 	pip install pydispatcher

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -22,6 +22,7 @@ if lsb_release -d | grep -q "Fedora"; then
 	pip install --upgrade urllib3
 	pip install setuptools
 	pip install pycrypto
+	pip install cryptography
 	pip install iptools
 	pip install pydispatcher
 	pip install flask

--- a/setup/setup_database.py
+++ b/setup/setup_database.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-import sqlite3, os, string, hashlib
-from Crypto.Random import random
+import sqlite3, os, string, hashlib, random
 
 
 ###################################################


### PR DESCRIPTION
This PR addresses the request made in #707.  I chose to use [cryptography](https://github.com/pyca/cryptography) for the crypto library as it is very mature(as python goes) and under heavy development and it is very likely to be installed already.  The only place that cryptography is actually used is in ```encryption.py```.  The use of ```random```(previously used by pycrypto's random function) is replaced by ```os.urandom```, in the places where keys or IVs are being generated(this is is cryptography's preferred solution to generating pseudo-random key material), in some cases I have swapped out PyCrypto's random function for python's standard library random.  This second use of random do not relate to direct use within crypto.

Testing:
I manually walked through the old AES functions and new AES functions in the interpreter while I was debugging things.  I also set up a new instance of Empire and spawned a listener and agent that successfully connected back.  I still would recommend testing these changes in dev for a decent bit!
 
There is one more reference to PyCrypto in the code, but that appeared to be related to something client side.