### PR TITLE
Make compatible with more recent pyopenssl, #697

### DIFF
--- a/data/agent/stagers/dropbox.py
+++ b/data/agent/stagers/dropbox.py
@@ -52,14 +52,9 @@ for name, ID in ADDITIONAL.items(): ADDITIONAL_IDS[ID] = name
 
 # If a secure random number generator is unavailable, exit with an error.
 try:
-    try:
-        import ssl
-        random_function = ssl.RAND_bytes
-        random_provider = "Python SSL"
-    except (AttributeError, ImportError):
-        import OpenSSL
-        random_function = OpenSSL.rand.bytes
-        random_provider = "OpenSSL"
+    import ssl
+    random_function = ssl.RAND_bytes
+    random_provider = "Python SSL"
 except:
     random_function = os.urandom
     random_provider = "os.urandom"

--- a/data/agent/stagers/http.py
+++ b/data/agent/stagers/http.py
@@ -53,14 +53,9 @@ for name, ID in ADDITIONAL.items(): ADDITIONAL_IDS[ID] = name
 
 # If a secure random number generator is unavailable, exit with an error.
 try:
-    try:
-        import ssl
-        random_function = ssl.RAND_bytes
-        random_provider = "Python SSL"
-    except (AttributeError, ImportError):
-        import OpenSSL
-        random_function = OpenSSL.rand.bytes
-        random_provider = "OpenSSL"
+    import ssl
+    random_function = ssl.RAND_bytes
+    random_provider = "Python SSL"
 except:
     random_function = os.urandom
     random_provider = "os.urandom"

--- a/lib/common/encryption.py
+++ b/lib/common/encryption.py
@@ -22,6 +22,7 @@ Includes:
 import base64
 import hashlib
 import hmac
+import os
 import string
 import M2Crypto
 
@@ -57,11 +58,9 @@ try:
     import ssl
     random_function = ssl.RAND_bytes
     random_provider = "Python SSL"
-except (AttributeError, ImportError):
-    import OpenSSL
-    random_function = OpenSSL.rand.bytes
-    random_provider = "OpenSSL"
-
+except:
+    random_function = os.urandom
+    random_provider = "os.urandom"
 
 def pad(data):
     """
@@ -285,7 +284,7 @@ class DiffieHellman(object):
                 _rand = int.from_bytes(random_function(_bytes), byteorder='big')
             except:
                 # Python 2
-                _rand = int(OpenSSL.rand.bytes(_bytes).encode('hex'), 16)
+                _rand = int(random_function(_bytes).encode('hex'), 16)
 
         return _rand
 

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -27,7 +27,7 @@ if lsb_release -d | grep -q "Fedora"; then
 	pip install flask
 	pip install macholib
 	pip install dropbox
-	pip install 'pyopenssl==17.2.0'
+	pip install pyopenssl
 	pip install pyinstaller
 	pip install zlib_wrapper
 	pip install netifaces
@@ -42,7 +42,7 @@ elif lsb_release -d | grep -q "Kali"; then
 	pip install flask
 	pip install macholib
 	pip install dropbox
-	pip install 'pyopenssl==17.2.0'
+	pip install pyopenssl
 	pip install pyinstaller
 	pip install zlib_wrapper
 	pip install netifaces
@@ -83,7 +83,7 @@ elif lsb_release -d | grep -q "Ubuntu"; then
 	pip install pyOpenSSL
 	pip install macholib
 	pip install dropbox
-	pip install 'pyopenssl==17.2.0'
+	pip install pyopenssl
 	pip install pyinstaller
 	pip install zlib_wrapper
 	pip install netifaces
@@ -113,7 +113,7 @@ else
 	 pip install dropbox
 	 pip install cryptography
 	 pip install pyOpenSSL
-	 pip install 'pyopenssl==17.2.0'
+	 pip install pyopenssl
 	 pip install zlib_wrapper
 	 pip install netifaces
 	 pip install M2Crypto


### PR DESCRIPTION
I tried to get empire working on Arch and figured instead of using virtualenv or downgrading pyopenssl I'd just use `os.urandom` instead. Seems to work fine so far with a ([PKGBUILD](https://github.com/lsfxz/blackarch-ruby/blob/master/empire/PKGBUILD) which pulls in pyopenssl 17.3.