### PR TITLE
fix broken call to generate  on dropbox exfil module, caused by invoke-obfuscation changes

### DIFF
--- a/lib/modules/powershell/exfiltration/exfil_dropbox.py
+++ b/lib/modules/powershell/exfiltration/exfil_dropbox.py
@@ -84,7 +84,7 @@ class Module:
                 if option in self.options:
                     self.options[option]['Value'] = value
 
-    def generate(self):
+    def generate(self, obfuscate=False, obfuscationCommand=""):
 
         script = """
 function Invoke-DropboxUpload {
@@ -137,5 +137,5 @@ Invoke-DropboxUpload  """
                         script += " -" + str(option)
                     else:
                         script += " -" + str(option) + " " + str(values['Value'])
-
+        
         return script


### PR DESCRIPTION
Invoke obfuscation changed the function signature for generate, but this module wasn't updated, or was reverted to the old signature at somepoint. 

Probably worth reviewing all the modules to make sure they all have the correct function signature. 