### PR TITLE
Fix padding error in stagers, should fix #586

### DIFF
--- a/data/agent/stagers/dropbox.py
+++ b/data/agent/stagers/dropbox.py
@@ -247,11 +247,8 @@ except Exception:
         return c
 
 def append_PKCS7_padding(data):
-    if (len(data) % 16) == 0:
-        return data
-    else:
-        pad = 16 - (len(data) % 16)
-        return data + to_bufferable(chr(pad) * pad)
+    pad = 16 - (len(data) % 16)
+    return data + to_bufferable(chr(pad) * pad)
 
 
 def strip_PKCS7_padding(data):
@@ -259,11 +256,7 @@ def strip_PKCS7_padding(data):
         raise ValueError("invalid length")
 
     pad = _get_byte(data[-1])
-
-    if pad <= 16:
-        return data[:-pad]
-    else:
-        return data
+    return data[:-pad]
 
 class AES(object):
     '''Encapsulates the AES block cipher.
@@ -522,10 +515,13 @@ class AESModeOfOperationCBC(AESBlockModeOfOperation):
 
 def CBCenc(aesObj, plaintext, base64=False):
 
-    # break the blocks in 16 byte chunks, padding the last chunk if necessary
-    blocks = [plaintext[0+i:16+i] for i in range(0, len(plaintext), 16)]
-    blocks[-1] = append_PKCS7_padding(blocks[-1])
+    # First we padd the plaintext
+    paddedPlaintext = append_PKCS7_padding(plaintext)
+    
+    # The we break the padded plaintext in 16 byte chunks
+    blocks = [paddedPlaintext[0+i:16+i] for i in range(0, len(paddedPlaintext), 16)]
 
+    # Finally we encypt each block
     ciphertext = ""
     for block in blocks:
         ciphertext += aesObj.encrypt(block)
@@ -535,15 +531,16 @@ def CBCenc(aesObj, plaintext, base64=False):
 
 def CBCdec(aesObj, ciphertext, base64=False):
 
-    # break the blocks in 16 byte chunks, padding the last chunk if necessary
+    # First we break the cyphertext in 16 byte chunks
     blocks = [ciphertext[0+i:16+i] for i in range(0, len(ciphertext), 16)]
 
-    plaintext = ""
+    # Then we decrypt each block
+    paddedPlaintext = ""
+    for block in blocks:
+        paddedPlaintext += aesObj.decrypt(block)
 
-    for x in xrange(0, len(blocks)-1):
-        plaintext += aesObj.decrypt(blocks[x])
-
-    plaintext += strip_PKCS7_padding(aesObj.decrypt(blocks[-1]))
+    # Finally we strip the padding 
+    plaintext = strip_PKCS7_padding(paddedPlaintext)
 
     return plaintext
 

--- a/data/agent/stagers/http.py
+++ b/data/agent/stagers/http.py
@@ -251,13 +251,9 @@ except Exception:
     def _get_byte(c):
         return c
 
-
 def append_PKCS7_padding(data):
-    if (len(data) % 16) == 0:
-        return data
-    else:
-        pad = 16 - (len(data) % 16)
-        return data + to_bufferable(chr(pad) * pad)
+    pad = 16 - (len(data) % 16)
+    return data + to_bufferable(chr(pad) * pad)
 
 
 def strip_PKCS7_padding(data):
@@ -265,11 +261,7 @@ def strip_PKCS7_padding(data):
         raise ValueError("invalid length")
 
     pad = _get_byte(data[-1])
-
-    if pad <= 16:
-        return data[:-pad]
-    else:
-        return data
+    return data[:-pad]
 
 
 class AES(object):
@@ -530,10 +522,13 @@ class AESModeOfOperationCBC(AESBlockModeOfOperation):
 
 def CBCenc(aesObj, plaintext, base64=False):
 
-    # break the blocks in 16 byte chunks, padding the last chunk if necessary
-    blocks = [plaintext[0+i:16+i] for i in range(0, len(plaintext), 16)]
-    blocks[-1] = append_PKCS7_padding(blocks[-1])
+    # First we padd the plaintext
+    paddedPlaintext = append_PKCS7_padding(plaintext)
+    
+    # The we break the padded plaintext in 16 byte chunks
+    blocks = [paddedPlaintext[0+i:16+i] for i in range(0, len(paddedPlaintext), 16)]
 
+    # Finally we encypt each block
     ciphertext = ""
     for block in blocks:
         ciphertext += aesObj.encrypt(block)
@@ -543,15 +538,16 @@ def CBCenc(aesObj, plaintext, base64=False):
 
 def CBCdec(aesObj, ciphertext, base64=False):
 
-    # break the blocks in 16 byte chunks, padding the last chunk if necessary
+    # First we break the cyphertext in 16 byte chunks
     blocks = [ciphertext[0+i:16+i] for i in range(0, len(ciphertext), 16)]
 
-    plaintext = ""
+    # Then we decrypt each block
+    paddedPlaintext = ""
+    for block in blocks:
+        paddedPlaintext += aesObj.decrypt(block)
 
-    for x in xrange(0, len(blocks)-1):
-        plaintext += aesObj.decrypt(blocks[x])
-
-    plaintext += strip_PKCS7_padding(aesObj.decrypt(blocks[-1]))
+    # Finally we strip the padding 
+    plaintext = strip_PKCS7_padding(paddedPlaintext)
 
     return plaintext
 


### PR DESCRIPTION
Hi!
I've investigating about the issue #586 and found the root cause of the problem. As @xorrior suggested the bug is similar to a previous issue (#458).

So my main modifications are : 
- Fix the padding (see #492)
- Fix the encryption flow. Indeed, in the original code, the padding is added at blocks level. The correct way to padd is to work at the plaintext level.

If you want to reproduce the bug, just type `shell a 2>&1` in a python agent. You should have no output in your Empire session because the output length matches the case where the padding is incorrect. With this PR, you'll be able to see the result of the command.

It was very fun to dig into the code!

TPWSOS :sunflower: 

PS: I don't test the dropbox listener, if someone can test before merging thx.