### PR TITLE
Fix Proxy Settings

### DIFF
--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -249,8 +249,7 @@ class Listener:
                             stager += helpers.randomize_capitalization("$wc.Proxy=[System.Net.WebRequest]::DefaultWebProxy;")
                         else:
                             # TODO: implement form for other proxy
-                            stager += helpers.randomize_capitalization("$proxy=New-Object Net.WebProxy;")
-                            stager += helpers.randomize_capitalization("$proxy.Address = '"+ proxy.lower() +"';")
+                            stager += helpers.randomize_capitalization("$proxy=New-Object Net.WebProxy('"+ proxy.lower() +"');")
                             stager += helpers.randomize_capitalization("$wc.Proxy = $proxy;")
                         if proxyCreds.lower() == "default":
                             stager += helpers.randomize_capitalization("$wc.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials;")
@@ -258,9 +257,13 @@ class Listener:
                             # TODO: implement form for other proxy credentials
                             username = proxyCreds.split(':')[0]
                             password = proxyCreds.split(':')[1]
-                            domain = username.split('\\')[0]
-                            usr = username.split('\\')[1]
-                            stager += "$netcred = New-Object System.Net.NetworkCredential('"+usr+"','"+password+"','"+domain+"');"
+                            if len(username.split('\\')) > 1:
+                                usr = username.split('\\')[1]
+                                domain = username.split('\\')[0]
+                                stager += "$netcred = New-Object System.Net.NetworkCredential('"+usr+"','"+password+"','"+domain+"');"
+                            else:
+                                usr = username.split('\\')[0]
+                                stager += "$netcred = New-Object System.Net.NetworkCredential('"+usr+"','"+password+"');"
                             stager += helpers.randomize_capitalization("$wc.Proxy.Credentials = $netcred;")
 
                         #save the proxy settings to use during the entire staging process and the agent
@@ -766,7 +769,7 @@ def send_message(packets=None):
         #if signaled for restaging, exit.
         if HTTPError.code == 401:
             sys.exit(0)
-        
+
         return (HTTPError.code, '')
 
     except urllib2.URLError as URLerror:


### PR DESCRIPTION
This PR fixes the following problem.

Empire Version: 2.2
OS Information: Kali 
```
(Empire: listeners/http) > set ProxyCreds 1:1
(Empire: listeners/http) > execute
[*] Starting listener 'http11'
[+] Listener successfully started!
```
When a new session is about to be established, I've got the following error:
```
(Empire: listeners/http) > [2017-10-29 09:53:36,928] ERROR in app: Exception on /t.ps1 [GET]
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/opt/Empire//lib/listeners/http.py", line 807, in send_stager
    launcher = self.mainMenu.stagers.generate_launcher(listenerName, language='powershell', encode=False, userAgent=userAgent, proxy=proxy, proxyCreds=proxyCreds)
  File "/opt/Empire/lib/common/stagers.py", line 99, in generate_launcher
    launcherCode = self.mainMenu.listeners.loadedListeners[activeListener['moduleName']].generate_launcher(encode=encode, obfuscate=obfuscate, obfuscationCommand=obfuscationCommand, userAgent=userA
gent, proxy=proxy, proxyCreds=proxyCreds, stagerRetries=stagerRetries, language=language, listenerName=listenerName, safeChecks=safeChecks)
  File "/opt/Empire//lib/listeners/http.py", line 262, in generate_launcher
    usr = username.split('\\')[1]
```

Furthermore, `$wC` object failed when proxy credentials were provided providing the following error message:

```
Exception calling "DownloadData" with "1" argument(s): "An exception occurred during a WebClient request."
At line:1 char:1424
+ ... L4UiwqsHLdntf/87nA1iG+doz8=");$DAta=$wC.DOwNLOadDAta($SEr+$T);$iV=$DA ...
+                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException

Cannot index into a null array.
```
This PR handles that as well.