### PR TITLE
Add basic plugin functionality to Empire

### DIFF
--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -408,8 +408,8 @@ class MainMenu(cmd.Cmd):
         if numFound > 0:
             print("\tName\tActive")
             print("\t----\t------")
+            activePlugins = self.loadedPlugins.keys()
             for name in pluginNames:
-                activePlugins = self.loadedPlugins.keys()
                 active = ""
                 if name in activePlugins:
                     active = "******"
@@ -428,18 +428,10 @@ class MainMenu(cmd.Cmd):
         pluginNames = [name for _, name, _ in pkgutil.walk_packages([pluginPath])]
         if pluginName in pluginNames:
             print(helpers.color("[*] Plugin {} found.".format(pluginName)))
-            # note the 'plugins' package so the loader can find our plugin
-            fullPluginName = "plugins." + pluginName
-            plugin = importlib.import_module(fullPluginName)
-
-            self.load_plugin(plugin, pluginName)
+            # 'self' is the mainMenu object
+            plugins.load_plugin(self, pluginName)
         else:
             raise Exception("[!] Error: the plugin specified does not exist in {}.".format(pluginPath))
-
-    def load_plugin(self, module, pluginName):
-        # "self" refers to the mainmenu object
-        plugin = module.Plugin(self)
-        self.loadedPlugins[pluginName] = plugin
 
     def postcmd(self, stop, line):
 	if len(self.resourceQueue) > 0:

--- a/lib/common/plugins.py
+++ b/lib/common/plugins.py
@@ -1,6 +1,16 @@
 """ Utilities and helpers and etc. for plugins """
 
+import importlib
+
 import lib.common.helpers as helpers
+
+def load_plugin(mainMenu, pluginName):
+    """ Given the name of a plugin and a menu object, load it into the menu """
+    # note the 'plugins' package so the loader can find our plugin
+    fullPluginName = "plugins." + pluginName
+    module = importlib.import_module(fullPluginName)
+    pluginObj = module.Plugin(mainMenu)
+    mainMenu.loadedPlugins[pluginName] = pluginObj
 
 class Plugin(object):
     # to be overwritten by child

--- a/lib/common/plugins.py
+++ b/lib/common/plugins.py
@@ -1,0 +1,31 @@
+""" Utilities and helpers and etc. for plugins """
+
+import lib.common.helpers as helpers
+
+class Plugin(object):
+    # to be overwritten by child
+    description = "This is a description of this plugin."
+
+    def __init__(self, mainMenu):
+        # having these multiple messages should be helpful for debugging
+        # user-reported errors (can narrow down where they happen)
+        print(helpers.color("[*] Initializing plugin..."))
+        # any future init stuff goes here
+
+        print(helpers.color("[*] Doing custom initialization..."))
+        # do custom user stuff
+        self.onLoad()
+
+        # now that everything is loaded, register functions and etc. onto the main menu
+        print(helpers.color("[*] Registering plugin with menu..."))
+        self.register(mainMenu)
+
+    def onLoad(self):
+        """ Things to do during init: meant to be overridden by
+        the inheriting plugin. """
+        pass
+
+    def register(self, mainMenu):
+        """ Any modifications made to the main menu are done here
+        (meant to be overriden by child) """
+        pass

--- a/plugins/example.py
+++ b/plugins/example.py
@@ -1,0 +1,35 @@
+""" An example of a plugin. """
+
+from lib.common.plugins import Plugin
+import lib.common.helpers as helpers
+
+# anything you simply write out (like a script) will run immediately when the
+# module is imported (before the class is instantiated)
+print("Hello from your new plugin!")
+
+# this class MUST be named Plugin
+class Plugin(Plugin):
+    description = "An example plugin."
+
+    def onLoad(self):
+        """ any custom loading behavior - called by init, so any
+        behavior you'd normally put in __init__ goes here """
+        print("Custom loading behavior happens now.")
+
+        # you can store data here that will persist until the plugin
+        # is unloaded (i.e. Empire closes)
+        self.calledTimes = 0
+
+    def register(self, mainMenu):
+        """ any modifications to the mainMenu go here - e.g.
+        registering functions to be run by user commands """
+        mainMenu.__class__.do_test = self.do_test
+
+    def do_test(self, args):
+        "An example of a plugin function."
+        print("This is executed from a plugin!")
+        print(helpers.color("[*] It can even import Empire functionality!"))
+
+        # you can also store data in the plugin (see onLoad)
+        self.calledTimes += 1
+        print("This function has been called {} times.".format(self.calledTimes))


### PR DESCRIPTION
Still basic, but I think it's a good start.

To test:

(open empire)
```
plugins
(some output showing one row, "example", not active)
plugin example
(some output showing it's loading)
plugins
(some output, should see stars under "loaded")
help
(output, should see option "test" listed)
test
(MAGIC)
```

Current limitations:
- no unloading functionality