### PR TITLE
Allow distinct values between the Host and Port options

### DIFF
--- a/lib/common/listeners.py
+++ b/lib/common/listeners.py
@@ -102,14 +102,16 @@ class Listeners:
                     if len(parts) != 1 and parts[-1].isdigit():
                         # if a port is specified with http://host:port
                         listenerObject.options['Host']['Value'] = "%s://%s" % (protocol, value)
-                        listenerObject.options['Port']['Value'] = parts[-1]
+                        if listenerObject.options['Port']['Value'] == '':
+                            listenerObject.options['Port']['Value'] = parts[-1]
                     elif listenerObject.options['Port']['Value'] != '':
                         # otherwise, check if the port value was manually set
                         listenerObject.options['Host']['Value'] = "%s://%s:%s" % (protocol, value, listenerObject.options['Port']['Value'])
                     else:
                         # otherwise use default port
                         listenerObject.options['Host']['Value'] = "%s://%s" % (protocol, value)
-                        listenerObject.options['Port']['Value'] = defaultPort
+                        if listenerObject.options['Port']['Value'] == '':
+                            listenerObject.options['Port']['Value'] = defaultPort
 
                     return True
 
@@ -123,11 +125,6 @@ class Listeners:
 
                 if option == 'Port':
                     listenerObject.options[option]['Value'] = value
-                    # set the port in the Host configuration as well
-                    host = listenerObject.options['Host']['Value']
-                    parts = host.split(':')
-                    if len(parts) == 2 or len(parts) == 3:
-                        listenerObject.options['Host']['Value'] = "%s:%s:%s" % (parts[0], parts[1], str(value))
                     return True
 
                 elif option == 'StagingKey':


### PR DESCRIPTION
This fix for issue https://github.com/EmpireProject/Empire/issues/825 allows to set distinct port values between the Host and Port options, thus allowing to use Empire behind port forwarding.

Currently, setting the Host option automatically modifies the Port option, and vice versa. Consequently, a single http listener can't be configured with a public port and a different listening private port.

TODO: fix the listeners: the port in the Host option is currently overwritten with the Port option if BindIP is an IPv6 address (if BindIP contains ':')