### PR TITLE
Docker build release

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -ex
+# SET THE FOLLOWING VARIABLES
+# docker hub username
+USERNAME=empireproject
+# image name
+IMAGE=empire
+docker build -t $USERNAME/$IMAGE:latest .

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ empire.debug
 *.pyc
 downloads/*
 .vscode/*
+.idea/*
 *.txt
 LastTask*
 data/obfuscated_module_source/*.ps1

--- a/.release.sh
+++ b/.release.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -ex
+
+# SET THE FOLLOWING VARIABLES
+USERNAME=empireproject
+IMAGE=empire
+VERSION="$(curl -s https://raw.githubusercontent.com/EmpireProject/Empire/master/lib/common/empire.py | grep "VERSION =" | cut -d '"' -f2)"
+
+# UPDATE THE SOURCE CODE
+git pull
+
+# ALERT VERSION
+echo "Building Version: $VERSION"
+
+# START BUILD
+./.build.sh
+
+# DOCKER TAG/VERSIONING
+docker tag $USERNAME/$IMAGE:latest $USERNAME/$IMAGE:$VERSION
+
+# PUSH TO DOCKER HUB
+docker push $USERNAME/$IMAGE:latest
+echo "Docker image pushed: $USERNAME/$IMAGE:latest"
+docker push $USERNAME/$IMAGE:$VERSION
+echo "Docker image pushed: $USERNAME/$IMAGE:$VERSION"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# NOTE: Only use this when you want to build image locally
+#       else use `docker pull empireproject\empire:{VERSION}`
+#       all image versions can be found at: https://hub.docker.com/r/empireproject/empire/
+
+# -----BUILD COMMANDS----
+# 1) build command: `docker build -t empireproject/empire .`
+# 2) create volume storage: `docker create -v /opt/Empire --name data empireproject/empire`
+# 3) run out container: `docker run -ti --volumes-from data empireproject/empire /bin/bash`
+
+# -----RELEASE COMMANDS----
+# 1) `USERNAME=empireproject`
+# 2) `IMAGE=empire`
+# 3) `git pull`
+# 4) `export VERSION="$(curl -s https://raw.githubusercontent.com/EmpireProject/Empire/master/lib/common/empire.py | grep "VERSION =" | cut -d '"' -f2)"`
+# 5) `docker tag $USERNAME/$IMAGE:latest $USERNAME/$IMAGE:$VERSION`
+# 1) `docker push $USERNAME/$IMAGE:latest`
+# 2) `docker push $USERNAME/$IMAGE:$VERSION`
+
+# -----BUILD ENTRY-----
+
+# image base
+FROM ubuntu:16.04
+
+# author
+MAINTAINER Killswitch-GUI
+
+# extra metadata
+LABEL version="1.0"
+LABEL description="Dockerfile base for Empire server."
+
+# expose ports for Empire C2 listerners
+# EXPOSE 80,443
+
+# update repo sources
+RUN apt-get clean
+RUN apt-get update
+
+# build depends
+RUN apt-get install -qy apt-utils
+RUN apt-get install -qy git
+RUN apt-get install -qy wget
+RUN apt-get install -qy curl
+RUN apt-get install -qy sudo
+RUN apt-get install -qy lsb-core
+RUN apt-get install -qy python2.7
+RUN apt-get install -qy python-pip
+
+# cleanup image
+RUN apt-get -qy autoremove
+
+# build empire
+RUN git clone https://github.com/EmpireProject/Empire.git /opt/Empire
+ENV STAGING_KEY=RANDOM
+RUN cd /opt/Empire/setup/ && ./install.sh
+
+# -----END OF BUILD-----
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 
 Empire is a post-exploitation framework that includes a pure-PowerShell2.0 Windows agent, and a pure Python 2.6/2.7 Linux/OS X agent. It is the merge of the previous PowerShell Empire and Python EmPyre projects. The framework offers cryptologically-secure communications and a flexible architecture. On the PowerShell side, Empire implements the ability to run PowerShell agents without needing powershell.exe, rapidly deployable post-exploitation modules ranging from key loggers to Mimikatz, and adaptable communications to evade network detection, all wrapped up in a usability-focused framework. PowerShell Empire premiered at [BSidesLV in 2015](https://www.youtube.com/watch?v=Pq9t59w0mUI) and Python EmPyre premeiered at HackMiami 2016.
 
-To install, run the `./setup/install.sh` script. There's also a [quickstart here](http://www.powershellempire.com/?page_id=110) and full [documentation here](http://www.powershellempire.com/?page_id=83).
-
 Empire relies heavily on the work from several other projects for its underlying functionality. We have tried to call out a few of those people we've interacted with [heavily here](http://www.powershellempire.com/?page_id=2) and have included author/reference link information in the source of each Empire module as appropriate. If we have failed to improperly cite existing or prior work, please let us know.
 
 Empire is developed by [@harmj0y](https://twitter.com/harmj0y), [@sixdub](https://twitter.com/sixdub), [@enigma0x3](https://twitter.com/enigma0x3), [rvrsh3ll](https://twitter.com/424f424f), [@killswitch_gui](https://twitter.com/killswitch_gui), and [@xorrior](https://twitter.com/xorrior).
 
 Feel free to join us on Slack! http://adaptiveempire.herokuapp.com/
 
+## Install
+
+To install, run the `./setup/install.sh` script or use the corresponding docker image `docker pull empireproject/empire`.
+
+There's also a [quickstart here](http://www.powershellempire.com/?page_id=110) and full [documentation here](http://www.powershellempire.com/?page_id=83).
 
 ## Contribution Rules
 

--- a/changelog
+++ b/changelog
@@ -2,6 +2,8 @@ Running
 ------------
 - Added Kevin Robertson's Invoke-SMBExec.ps1
 - Update Invoke-DCOM
+- Added Dockerfile, Docker Hub images, Build/Release scripts
+- Updated README for cleaner install instructions with new options
 
 10/29/2017
 ------------


### PR DESCRIPTION
List of changes:

1. Updated README to in hopes to make install instructions a bit cleaner (can revert if needed/disagree), but it was a potential cleaner way of letting newcomers to quickly ID  the install process and docs
2. Added `.build.sh` to build the docker image 
3. Added `.release.sh` to fill out all the required data and push to Docker hub automatically. 
4. Added `Dockerfile` with comments about the build process in case others want to build the image manually.

Offical Images can be here: https://hub.docker.com/r/empireproject/empire/
Devs: Will be added to the Docker hub org.