### PR TITLE
add CORS * header to all REST API responses

### DIFF
--- a/empire
+++ b/empire
@@ -223,6 +223,11 @@ def start_restful_api(empireMenu, suppress=False, username=None, password=None, 
             if (token != apiToken) and (token != permanentApiToken):
                 return make_response('', 401)
 
+    @app.after_request
+    def add_cors(response):
+        response.headers['Access-Control-Allow-Origin'] = '*'
+        return response
+
 
     @app.errorhandler(Exception)
     def exception_handler(error):


### PR DESCRIPTION
This will allow e.g. a javascript app to fetch resources from the Empire API even if it's not hosted at the same URI as the Empire API (which it likely won't be, since the Empire API can't host arbitrary things).

Since there's a token required to access every endpoint anyway, I don't believe this poses a security risk.