### PR TITLE
More robust password prompt handler

### DIFF
--- a/lib/modules/python/lateral_movement/multi/ssh_command.py
+++ b/lib/modules/python/lateral_movement/multi/ssh_command.py
@@ -107,7 +107,7 @@ def wall(host, pw):
     while True:
         try:
             data = os.read(fd, 1024)
-            if data == "Password:":
+            if data[:8] == "Password" and data[-1:] == ":":
                 os.write(fd, pw + '\\n')
 
         except OSError:

--- a/lib/modules/python/lateral_movement/multi/ssh_launcher.py
+++ b/lib/modules/python/lateral_movement/multi/ssh_launcher.py
@@ -121,7 +121,7 @@ def wall(host, pw):
     while True:
         try:
             data = os.read(fd, 1024)
-            if data == "Password:":
+            if data[:8] == "Password" and data[-1:] == ":":
                 os.write(fd, pw + '\\n')
 
         except OSError:


### PR DESCRIPTION
Some SSH clients use a more verbose password prompt: "Password for user@pfSense.domain.local:". This patch makes the parent process wait for any string starting with "Password" and ending with ":"