### PR TITLE
Include Docker and non-docker paths in template search, fix #904

### DIFF
--- a/lib/listeners/dbx.py
+++ b/lib/listeners/dbx.py
@@ -431,7 +431,9 @@ class Listener:
 
 
         elif language.lower() == 'python':
-            template_path = os.path.join(self.mainMenu.installPath, '/data/agent/stagers')
+            template_path = [
+                os.path.join(self.mainMenu.installPath, '/data/agent/stagers'),
+                os.path.join(self.mainMenu.installPath, './data/agent/stagers')]
             eng = templating.TemplateEngine(template_path)
             template = eng.get_template('dropbox.py')
 

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -591,7 +591,9 @@ class Listener:
                 return randomizedStager
 
         elif language.lower() == 'python':
-            template_path = os.path.join(self.mainMenu.installPath, 'data/agent/stagers')
+            template_path = [
+                os.path.join(self.mainMenu.installPath, '/data/agent/stagers'),
+                os.path.join(self.mainMenu.installPath, './data/agent/stagers')]
             eng = templating.TemplateEngine(template_path)
             template = eng.get_template('http.py')
 
@@ -898,7 +900,7 @@ def send_message(packets=None):
                 return launcher
             else:
                 return make_response(self.default_response(), 404)
-        
+
         @app.before_request
         def check_ip():
             """
@@ -930,7 +932,7 @@ def send_message(packets=None):
             """
             Return default server web page if user navigates to index.
             """
-            
+
             static_dir = self.mainMenu.installPath + "data/misc/"
             return make_response(self.index_page(), 200)
 


### PR DESCRIPTION
This will first look for templates at `os.path.join(self.mainMenu.installPath, '/data/agent/stagers')`, then `os.path.join(self.mainMenu.installPath, './data/agent/stagers')`. The first should work for docker, and the second should work outside docker.

Kinda weird, though, since `installPath` should make this work either way... but that's for later investigation. (just now noticed it)