### PR TITLE
Overhaul events system

### DIFF
--- a/empire
+++ b/empire
@@ -1143,7 +1143,7 @@ def start_restful_api(empireMenu, suppress=False, username=None, password=None, 
 
         for reportingEvent in reportingRaw:
             [ID, name, event_type, message, time_stamp, taskID] = reportingEvent
-            reportingEvents.append({"ID":ID, "agentname":name, "event_type":event_type, "message":message, "timestamp":time_stamp, "taskID":taskID})
+            reportingEvents.append({"ID":ID, "agentname":name, "event_type":event_type, "message":json.loads(message), "timestamp":time_stamp, "taskID":taskID})
 
         return jsonify({'reporting' : reportingEvents})
 
@@ -1167,7 +1167,7 @@ def start_restful_api(empireMenu, suppress=False, username=None, password=None, 
 
         for reportingEvent in reportingRaw:
             [ID, name, event_type, message, time_stamp, taskID] = reportingEvent
-            reportingEvents.append({"ID":ID, "agentname":name, "event_type":event_type, "message":message, "timestamp":time_stamp, "taskID":taskID})
+            reportingEvents.append({"ID":ID, "agentname":name, "event_type":event_type, "message":json.loads(message), "timestamp":time_stamp, "taskID":taskID})
 
         return jsonify({'reporting' : reportingEvents})
 
@@ -1183,7 +1183,7 @@ def start_restful_api(empireMenu, suppress=False, username=None, password=None, 
 
         for reportingEvent in reportingRaw:
             [ID, name, event_type, message, time_stamp, taskID] = reportingEvent
-            reportingEvents.append({"ID":ID, "agentname":name, "event_type":event_type, "message":message, "timestamp":time_stamp, "taskID":taskID})
+            reportingEvents.append({"ID":ID, "agentname":name, "event_type":event_type, "message":json.loads(message), "timestamp":time_stamp, "taskID":taskID})
 
         return jsonify({'reporting' : reportingEvents})
 
@@ -1199,7 +1199,7 @@ def start_restful_api(empireMenu, suppress=False, username=None, password=None, 
 
         for reportingEvent in reportingRaw:
             [ID, name, event_type, message, time_stamp, taskID] = reportingEvent
-            reportingEvents.append({"ID":ID, "agentname":name, "event_type":event_type, "message":message, "timestamp":time_stamp, "taskID":taskID})
+            reportingEvents.append({"ID":ID, "agentname":name, "event_type":event_type, "message":json.loads(message), "timestamp":time_stamp, "taskID":taskID})
 
         return jsonify({'reporting' : reportingEvents})
 

--- a/lib/common/__init__.py
+++ b/lib/common/__init__.py
@@ -1,0 +1,23 @@
+"""
+Connect to the default database at ./data/empire.db.
+"""
+
+import sys
+import sqlite3
+
+import helpers
+
+def connect_to_db():
+    try:
+        # set the database connectiont to autocommit w/ isolation level
+        conn = sqlite3.connect('./data/empire.db', check_same_thread=False)
+        conn.text_factory = str
+        conn.isolation_level = None
+        return conn
+
+    except Exception:
+        print helpers.color("[!] Could not connect to database")
+        print helpers.color("[!] Please run database_setup.py")
+        sys.exit()
+
+db = connect_to_db()

--- a/lib/common/agents.py
+++ b/lib/common/agents.py
@@ -244,8 +244,12 @@ class Agents:
             # fix for 'skywalker' exploit by @zeroSteiner
             safePath = os.path.abspath("%sdownloads/" % self.installPath)
             if not os.path.abspath(save_path + "/" + filename).startswith(safePath):
-                dispatcher.send("[!] WARNING: agent %s attempted skywalker exploit!" % (sessionID), sender='Agents')
-                dispatcher.send("[!] attempted overwrite of %s with data %s" % (path, data), sender='Agents')
+                message = "[!] WARNING: agent {} attempted skywalker exploit!\n[!] attempted overwrite of {} with data {}".format(sessionID, path, data)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
                 return
 
             # make the recursive directory structure if it doesn't already exist
@@ -265,10 +269,12 @@ class Agents:
                 dec_data = d.dec_data(data)
                 print helpers.color("[*] Final size of %s wrote: %s" %(filename, helpers.get_file_size(dec_data['data'])), color="green")
                 if not dec_data['crc32_check']:
-                    dispatcher.send("[!] WARNING: File agent %s failed crc32 check during decompressing!." %(nameid))
-                    print helpers.color("[!] WARNING: File agent %s failed crc32 check during decompressing!." %(nameid))
-                    dispatcher.send("[!] HEADER: Start crc32: %s -- Received crc32: %s -- Crc32 pass: %s!." %(dec_data['header_crc32'],dec_data['dec_crc32'],dec_data['crc32_check']))
-                    print helpers.color("[!] HEADER: Start crc32: %s -- Received crc32: %s -- Crc32 pass: %s!." %(dec_data['header_crc32'],dec_data['dec_crc32'],dec_data['crc32_check']))
+                    message = "[!] WARNING: File agent {} failed crc32 check during decompression!\n[!] HEADER: Start crc32: %s -- Received crc32: %s -- Crc32 pass: %s!".format(nameid, dec_data['header_crc32'], dec_data['dec_crc32'], dec_data['crc32_check'])
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message
+                    })
+                    dispatcher.send(signal, sender="agents/{}".format(nameid))
                 data = dec_data['data']
 
             f.write(data)
@@ -277,8 +283,12 @@ class Agents:
             self.lock.release()
 
         # notify everyone that the file was downloaded
-        dispatcher.send("[+] Part of file %s from %s saved" % (filename, sessionID), sender='Agents')
-
+        message = "[+] Part of file %s from %s saved".format(filename, sessionID)
+        signal = json.dumps({
+            'print': True,
+            'message': message
+        })
+        dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
     def save_module_file(self, sessionID, path, data):
         """
@@ -300,10 +310,12 @@ class Agents:
             dec_data = d.dec_data(data)
             print helpers.color("[*] Final size of %s wrote: %s" %(filename, helpers.get_file_size(dec_data['data'])), color="green")
             if not dec_data['crc32_check']:
-                dispatcher.send("[!] WARNING: File agent %s failed crc32 check during decompressing!." %(nameid))
-                print helpers.color("[!] WARNING: File agent %s failed crc32 check during decompressing!." %(nameid))
-                dispatcher.send("[!] HEADER: Start crc32: %s -- Received crc32: %s -- Crc32 pass: %s!." %(dec_data['header_crc32'],dec_data['dec_crc32'],dec_data['crc32_check']))
-                print helpers.color("[!] HEADER: Start crc32: %s -- Received crc32: %s -- Crc32 pass: %s!." %(dec_data['header_crc32'],dec_data['dec_crc32'],dec_data['crc32_check']))
+                message = "[!] WARNING: File agent {} failed crc32 check during decompression!\n[!] HEADER: Start crc32: %s -- Received crc32: %s -- Crc32 pass: %s!".format(nameid, dec_data['header_crc32'], dec_data['dec_crc32'], dec_data['crc32_check'])
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(nameid))
             data = dec_data['data']
 
         try:
@@ -311,8 +323,12 @@ class Agents:
             # fix for 'skywalker' exploit by @zeroSteiner
             safePath = os.path.abspath("%s/downloads/" % self.installPath)
             if not os.path.abspath(save_path + "/" + filename).startswith(safePath):
-                dispatcher.send("[!] WARNING: agent %s attempted skywalker exploit!" % (sessionID), sender='Agents')
-                dispatcher.send("[!] attempted overwrite of %s with data %s" % (path, data), sender='Agents')
+                message = "[!] WARNING: agent {} attempted skywalker exploit!\n[!] attempted overwrite of {} with data {}".format(sessionID, path, data)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
                 return
 
             # make the recursive directory structure if it doesn't already exist
@@ -327,8 +343,12 @@ class Agents:
             self.lock.release()
 
         # notify everyone that the file was downloaded
-        # dispatcher.send("[+] File "+path+" from "+str(sessionID)+" saved", sender='Agents')
-        dispatcher.send("[+] File %s from %s saved" % (path, sessionID), sender='Agents')
+        message = "[+] File {} from {} saved".format(path, sessionID)
+        signal = json.dumps({
+            'print': True,
+            'message': message
+        })
+        dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
         return "/downloads/%s/%s/%s" % (sessionID, "/".join(parts[0:-1]), filename)
 
@@ -846,7 +866,12 @@ class Agents:
             finally:
                 self.lock.release()
         else:
-            dispatcher.send("[!] Non-existent agent %s returned results" % (sessionID), sender='Agents')
+            message = "[!] Non-existent agent %s returned results".format(sessionID)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
 
     def update_agent_sysinfo_db(self, sessionID, listener='', external_ip='', internal_ip='', username='', hostname='', os_details='', high_integrity=0, process_name='', process_id='', language_version='', language=''):
@@ -1027,8 +1052,12 @@ class Agents:
             print helpers.color("[!] Agent %s not active." % (agentName))
         else:
             if sessionID:
-
-                dispatcher.send("[*] Tasked %s to run %s" % (sessionID, taskName), sender='Agents')
+                message = "[*] Tasked {} to run {}".format(sessionID, taskName)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
                 conn = self.get_db_connection()
                 try:
@@ -1184,7 +1213,12 @@ class Agents:
 
         elif meta == 'STAGE1':
             # step 3 of negotiation -> client posts public key
-            dispatcher.send("[*] Agent %s from %s posted public key" % (sessionID, clientIP), sender='Agents')
+            message = "[*] Agent {} from {} posted public key".format(sessionID, clientIP)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
             # decrypt the agent's public key
             try:
@@ -1192,7 +1226,12 @@ class Agents:
             except Exception as e:
                 print 'exception e:' + str(e)
                 # if we have an error during decryption
-                dispatcher.send("[!] HMAC verification failed from '%s'" % (sessionID), sender='Agents')
+                message = "[!] HMAC verification failed from '{}'".format(sessionID)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
                 return 'ERROR: HMAC verification failed'
 
             if language.lower() == 'powershell':
@@ -1201,14 +1240,24 @@ class Agents:
 
                 # client posts RSA key
                 if (len(message) < 400) or (not message.endswith("</RSAKeyValue>")):
-                    dispatcher.send("[!] Invalid PowerShell key post format from %s" % (sessionID), sender='Agents')
+                    message = "[!] Invalid PowerShell key post format from {}".format(sessionID)
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message
+                    })
+                    dispatcher.send(signal, sender="agents/{}".format(sessionID))
                     return 'ERROR: Invalid PowerShell key post format'
                 else:
                     # convert the RSA key from the stupid PowerShell export format
                     rsaKey = encryption.rsa_xml_to_key(message)
 
                     if rsaKey:
-                        dispatcher.send("[*] Agent %s from %s posted valid PowerShell RSA key" % (sessionID, clientIP), sender='Agents')
+                        message = "[*] Agent {} from {} posted valid PowerShell RSA key".format(sessionID, clientIP)
+                        signal = json.dumps({
+                            'print': True,
+                            'message': message
+                        })
+                        dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
                         nonce = helpers.random_string(16, charset=string.digits)
                         delay = listenerOptions['DefaultDelay']['Value']
@@ -1233,19 +1282,34 @@ class Agents:
                         return encryptedMsg
 
                     else:
-                        dispatcher.send("[!] Agent %s returned an invalid PowerShell public key!" % (sessionID), sender='Agents')
+                        message = "[!] Agent {} returned an invalid PowerShell public key!".format(sessionID)
+                        signal = json.dumps({
+                            'print': True,
+                            'message': message
+                        })
+                        dispatcher.send(signal, sender="agents/{}".format(sessionID))
                         return 'ERROR: Invalid PowerShell public key'
 
             elif language.lower() == 'python':
                 if ((len(message) < 1000) or (len(message) > 2500)):
-                    dispatcher.send("[!] Invalid Python key post format from %s" % (sessionID), sender='Agents')
+                    message = "[!] Invalid Python key post format from {}".format(sessionID)
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message
+                    })
+                    dispatcher.send(signal, sender="agents/{}".format(sessionID))
                     return "Error: Invalid Python key post format from %s" % (sessionID)
                 else:
                     try:
                         int(message)
                     except:
-                        dispatcher.send("[!] Invalid Python key post format from %s" % (sessionID), sender='Agents')
-                        return "Error: Invalid Python key post format from %s" % (sessionID)
+                        message = "[!] Invalid Python key post format from {}".format(sessionID)
+                        signal = json.dumps({
+                            'print': True,
+                            'message': message
+                        })
+                        dispatcher.send(signal, sender="agents/{}".format(sessionID))
+                        return "Error: Invalid Python key post format from {}".format(sessionID)
 
                     # client posts PUBc key
                     clientPub = int(message)
@@ -1255,7 +1319,12 @@ class Agents:
 
                     nonce = helpers.random_string(16, charset=string.digits)
 
-                    dispatcher.send("[*] Agent %s from %s posted valid Python PUB key" % (sessionID, clientIP), sender='Agents')
+                    message = "[*] Agent {} from {} posted valid Python PUB key".format(sessionID, clientIP)
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message
+                    })
+                    dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
                     delay = listenerOptions['DefaultDelay']['Value']
                     jitter = listenerOptions['DefaultJitter']['Value']
@@ -1275,8 +1344,13 @@ class Agents:
                     return encryptedMsg
 
             else:
-                dispatcher.send("[*] Agent %s from %s using an invalid language specification: %s" % (sessionID, clientIP, language), sender='Agents')
-                'ERROR: invalid language: %s' % (language)
+                message = "[*] Agent {} from {} using an invalid language specification: {}".format(sessionID, clientIP, language)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
+                return 'ERROR: invalid language: {}'.format(language)
 
         elif meta == 'STAGE2':
             # step 5 of negotiation -> client posts nonce+sysinfo and requests agent
@@ -1288,19 +1362,34 @@ class Agents:
                 parts = message.split('|')
 
                 if len(parts) < 12:
-                    dispatcher.send("[!] Agent %s posted invalid sysinfo checkin format: %s" % (sessionID, message), sender='Agents')
+                    message = "[!] Agent {} posted invalid sysinfo checkin format: {}".format(sessionID, message)
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message
+                    })
+                    dispatcher.send(signal, sender="agents/{}".format(sessionID))
                     # remove the agent from the cache/database
                     self.mainMenu.agents.remove_agent_db(sessionID)
                     return "ERROR: Agent %s posted invalid sysinfo checkin format: %s" % (sessionID, message)
 
                 # verify the nonce
                 if int(parts[0]) != (int(self.mainMenu.agents.get_agent_nonce_db(sessionID)) + 1):
-                    dispatcher.send("[!] Invalid nonce returned from %s" % (sessionID), sender='Agents')
+                    message = "[!] Invalid nonce returned from {}".format(sessionID)
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message
+                    })
+                    dispatcher.send(signal, sender="agents/{}".format(sessionID))
                     # remove the agent from the cache/database
                     self.mainMenu.agents.remove_agent_db(sessionID)
                     return "ERROR: Invalid nonce returned from %s" % (sessionID)
 
-                dispatcher.send("[!] Nonce verified: agent %s posted valid sysinfo checkin format: %s" % (sessionID, message), sender='Agents')
+                message = "[!] Nonce verified: agent {} posted valid sysinfo checkin format: {}".format(sessionID, message)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
                 listener = unicode(parts[1], 'utf-8')
                 domainname = unicode(parts[2], 'utf-8')
@@ -1320,7 +1409,12 @@ class Agents:
                     high_integrity = 0
 
             except Exception as e:
-                dispatcher.send("[!] Exception in agents.handle_agent_staging() for %s : %s" % (sessionID, e), sender='Agents')
+                message = "[!] Exception in agents.handle_agent_staging() for {} : {}".format(sessionID, e)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
                 # remove the agent from the cache/database
                 self.mainMenu.agents.remove_agent_db(sessionID)
                 return "Error: Exception in agents.handle_agent_staging() for %s : %s" % (sessionID, e)
@@ -1339,8 +1433,13 @@ class Agents:
                 slackText = ":biohazard: NEW AGENT :biohazard:\r\n```Machine Name: %s\r\nInternal IP: %s\r\nExternal IP: %s\r\nUser: %s\r\nOS Version: %s\r\nAgent ID: %s```" % (hostname,internal_ip,external_ip,username,os_details,sessionID)
                 helpers.slackMessage(slackToken,slackChannel,slackText)
 
-	        # signal everyone that this agent is now active
-            dispatcher.send("[+] Initial agent %s from %s now active (Slack)" % (sessionID, clientIP), sender='Agents')
+            # signal everyone that this agent is now active
+            message = "[+] Initial agent {} from {} now active (Slack)".format(sessionID, clientIP)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
             # save the initial sysinfo information in the agent log
             agent = self.mainMenu.agents.get_agent_db(sessionID)
@@ -1370,8 +1469,12 @@ class Agents:
             return "STAGE2: %s" % (sessionID)
 
         else:
-            dispatcher.send("[!] Invalid staging request packet from %s at %s : %s" % (sessionID, clientIP, meta), sender='Agents')
-
+            message = "[!] Invalid staging request packet from {} at {} : {}".format(sessionID, clientIP, meta)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
     def handle_agent_data(self, stagingKey, routingPacket, listenerOptions, clientIP='0.0.0.0'):
         """
@@ -1382,7 +1485,12 @@ class Agents:
         """
 
         if len(routingPacket) < 20:
-            dispatcher.send("[!] handle_agent_data(): routingPacket wrong length: %s" %(len(routingPacket)), sender='Agents')
+            message = "[!] handle_agent_data(): routingPacket wrong length: {}".format(routingPacket)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="empire")
             return None
 
         routingPacket = packets.parse_routing_packet(stagingKey, routingPacket)
@@ -1396,24 +1504,48 @@ class Agents:
         for sessionID, (language, meta, additional, encData) in routingPacket.iteritems():
 
             if meta == 'STAGE0' or meta == 'STAGE1' or meta == 'STAGE2':
-                dispatcher.send("[*] handle_agent_data(): sessionID %s issued a %s request" % (sessionID, meta), sender='Agents')
+                message = "[*] handle_agent_data(): sessionID {} issued a {} request".format(sessionID, meta)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
                 dataToReturn.append((language, self.handle_agent_staging(sessionID, language, meta, additional, encData, stagingKey, listenerOptions, clientIP)))
 
             elif sessionID not in self.agents:
-                dispatcher.send("[!] handle_agent_data(): sessionID %s not present" % (sessionID), sender='Agents')
+                message = "[!] handle_agent_data(): sessionID {} not present".format(sessionID)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
                 dataToReturn.append(('', "ERROR: sessionID %s not in cache!" % (sessionID)))
 
             elif meta == 'TASKING_REQUEST':
-                dispatcher.send("[*] handle_agent_data(): sessionID %s issued a TASKING_REQUEST" % (sessionID), sender='Agents')
+                message = "[*] handle_agent_data(): sessionID {} issued a TASKING_REQUEST".format(sessionID)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
                 dataToReturn.append((language, self.handle_agent_request(sessionID, language, stagingKey)))
 
             elif meta == 'RESULT_POST':
-                dispatcher.send("[*] handle_agent_data(): sessionID %s issued a RESULT_POST" % (sessionID), sender='Agents')
+                message = "[*] handle_agent_data(): sessionID %s issued a RESULT_POST".format(sessionID)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
                 dataToReturn.append((language, self.handle_agent_response(sessionID, encData)))
 
             else:
-                dispatcher.send("[!] handle_agent_data(): sessionID %s gave unhandled meta tag in routing packet: %s" % (sessionID, meta), sender='Agents')
-
+                message = "[!] handle_agent_data(): sessionID {} gave unhandled meta tag in routing packet: {}".format(sessionID, meta)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
         return dataToReturn
 
 
@@ -1424,7 +1556,12 @@ class Agents:
         TODO: does this need self.lock?
         """
         if sessionID not in self.agents:
-            dispatcher.send("[!] handle_agent_request(): sessionID %s not present" % (sessionID), sender='Agents')
+            message = "[!] handle_agent_request(): sessionID {} not present".format(sessionID)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(sessionID))
             return None
 
         # update the client's last seen time
@@ -1465,7 +1602,12 @@ class Agents:
         """
 
         if sessionID not in self.agents:
-            dispatcher.send("[!] handle_agent_response(): sessionID %s not in cache" % (sessionID), sender='Agents')
+            message = "[!] handle_agent_response(): sessionID {} not in cache".format(sessionID)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(sessionID))
             return None
 
         # extract the agent's session key
@@ -1494,16 +1636,26 @@ class Agents:
             cur.close()
             theSender="Agents"
             if data.startswith("function Get-Keystrokes"):
-		        theSender += "PsKeyLogger"
+                theSender += "PsKeyLogger"
             if results:
                 # signal that this agent returned results
-                dispatcher.send("[*] Agent %s returned results." % (sessionID), sender=theSender)
+                message = "[*] Agent {} returned results.".format(sessionID)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
             # return a 200/valid
             return 'VALID'
 
         except Exception as e:
-            dispatcher.send("[!] Error processing result packet from %s : %s" % (sessionID, e), sender='Agents')
+            message = "[!] Error processing result packet from {} : {}".format(sessionID, e)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
             # TODO: stupid concurrency...
             #   when an exception is thrown, something causes the lock to remain locked...
@@ -1559,7 +1711,12 @@ class Agents:
 
         if responseName == "ERROR":
             # error code
-            dispatcher.send("[!] Received error response from " + str(sessionID), sender='Agents')
+            message = "[!] Received error response from {}".format(sessionID)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(sessionID))
             self.update_agent_results_db(sessionID, data)
             # update the agent log
             self.save_agent_log(sessionID, "[!] Error response: " + data)
@@ -1569,7 +1726,12 @@ class Agents:
             # sys info response -> update the host info
             parts = data.split("|")
             if len(parts) < 12:
-                dispatcher.send("[!] Invalid sysinfo response from " + str(sessionID), sender='Agents')
+                message = "[!] Invalid sysinfo response from {}".format(sessionID)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
             else:
                 print "sysinfo:",data
                 # extract appropriate system information
@@ -1613,9 +1775,13 @@ class Agents:
 
         elif responseName == "TASK_EXIT":
             # exit command response
-            data = "[!] Agent %s exiting" % (sessionID)
             # let everyone know this agent exited
-            dispatcher.send(data, sender='Agents')
+            message = "[!] Agent {} exiting".format(sessionID)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
             # update the agent results and log
             # self.update_agent_results(sessionID, data)
@@ -1636,7 +1802,12 @@ class Agents:
             # file download
             parts = data.split("|")
             if len(parts) != 3:
-                dispatcher.send("[!] Received invalid file download response from " + sessionID, sender='Agents')
+                message = "[!] Received invalid file download response from {}".format(sessionID)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
             else:
                 index, path, data = parts
                 # decode the file data and save it off as appropriate
@@ -1737,7 +1908,12 @@ class Agents:
                 safePath = os.path.abspath("%sdownloads/" % self.mainMenu.installPath)
                 savePath = "%sdownloads/%s/keystrokes.txt" % (self.mainMenu.installPath,sessionID)
                 if not os.path.abspath(savePath).startswith(safePath):
-                    dispatcher.send("[!] WARNING: agent %s attempted skywalker exploit!" % (self.sessionID), sender='Agents')
+                    message = "[!] WARNING: agent {} attempted skywalker exploit!".format(self.sessionID)
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message
+                    })
+                    dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
                     return
 
                 with open(savePath,"a+") as f:
@@ -1821,7 +1997,12 @@ class Agents:
         elif responseName == "TASK_SWITCH_LISTENER":
             # update the agent listener
             self.update_agent_listener_db(sessionID, data)
-            dispatcher.send("[+] Listener for '%s' updated to '%s'" % (sessionID, data), sender='Agents')
+            message = "[+] Listener for '{}' updated to '{}'".format(sessionID, data)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
         else:
             print helpers.color("[!] Unknown response %s from %s" % (responseName, sessionID))

--- a/lib/common/agents.py
+++ b/lib/common/agents.py
@@ -1411,7 +1411,7 @@ class Agents:
 
                 message = "[!] Nonce verified: agent {} posted valid sysinfo checkin format: {}".format(sessionID, message)
                 signal = json.dumps({
-                    'print': True,
+                    'print': False,
                     'message': message
                 })
                 dispatcher.send(signal, sender="agents/{}".format(sessionID))
@@ -1512,7 +1512,7 @@ class Agents:
         if len(routingPacket) < 20:
             message = "[!] handle_agent_data(): routingPacket wrong length: {}".format(routingPacket)
             signal = json.dumps({
-                'print': True,
+                'print': False,
                 'message': message
             })
             dispatcher.send(signal, sender="empire")
@@ -1531,7 +1531,7 @@ class Agents:
             if meta == 'STAGE0' or meta == 'STAGE1' or meta == 'STAGE2':
                 message = "[*] handle_agent_data(): sessionID {} issued a {} request".format(sessionID, meta)
                 signal = json.dumps({
-                    'print': True,
+                    'print': False,
                     'message': message
                 })
                 dispatcher.send(signal, sender="agents/{}".format(sessionID))
@@ -1540,7 +1540,7 @@ class Agents:
             elif sessionID not in self.agents:
                 message = "[!] handle_agent_data(): sessionID {} not present".format(sessionID)
                 signal = json.dumps({
-                    'print': True,
+                    'print': False,
                     'message': message
                 })
                 dispatcher.send(signal, sender="agents/{}".format(sessionID))
@@ -1549,16 +1549,16 @@ class Agents:
             elif meta == 'TASKING_REQUEST':
                 message = "[*] handle_agent_data(): sessionID {} issued a TASKING_REQUEST".format(sessionID)
                 signal = json.dumps({
-                    'print': True,
+                    'print': False,
                     'message': message
                 })
                 dispatcher.send(signal, sender="agents/{}".format(sessionID))
                 dataToReturn.append((language, self.handle_agent_request(sessionID, language, stagingKey)))
 
             elif meta == 'RESULT_POST':
-                message = "[*] handle_agent_data(): sessionID %s issued a RESULT_POST".format(sessionID)
+                message = "[*] handle_agent_data(): sessionID {} issued a RESULT_POST".format(sessionID)
                 signal = json.dumps({
-                    'print': True,
+                    'print': False,
                     'message': message
                 })
                 dispatcher.send(signal, sender="agents/{}".format(sessionID))

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -90,7 +90,7 @@ class MainMenu(cmd.Cmd):
 
         dispatcher.connect(self.handle_event, sender=dispatcher.Any)
 
-        # Main, Agents, or 
+        # Main, Agents, or
         self.menu_state = 'Main'
 
         # parse/handle any passed command line arguments
@@ -799,16 +799,16 @@ class MainMenu(cmd.Cmd):
 
     def do_preobfuscate(self, line):
         "Preobfuscate PowerShell module_source files"
-        
+
         if not helpers.is_powershell_installed():
             print helpers.color("[!] PowerShell is not installed and is required to use obfuscation, please install it first.")
             return
-        
+
         module = line.strip()
         obfuscate_all = False
         obfuscate_confirmation = False
         reobfuscate = False
-        
+
         # Preobfuscate ALL module_source files
         if module == "" or module == "all":
             choice = raw_input(helpers.color("[>] Preobfuscate all PowerShell module_source files using obfuscation command: \"" + self.obfuscateCommand + "\"?\nThis may take a substantial amount of time. [y/N] ", "red"))
@@ -1875,7 +1875,7 @@ class PowerShellAgentMenu(SubMenu):
         "Task an agent to download a file."
 
         line = line.strip()
-        
+
         if line != "":
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_DOWNLOAD", line)
             # update the agent log
@@ -1901,7 +1901,7 @@ class PowerShellAgentMenu(SubMenu):
 
             if parts[0] != "" and os.path.exists(parts[0]):
                 # Check the file size against the upload limit of 1 mb
-                
+
                 # read in the file and base64 encode it for transport
                 open_file = open(parts[0], 'r')
                 file_data = open_file.read()
@@ -2788,7 +2788,7 @@ try:
     with open("%s","r") as f:
         for line in f:
             output += line
-    
+
     print output
 except Exception as e:
     print str(e)
@@ -2856,7 +2856,7 @@ except Exception as e:
 
         else:
             print helpers.color("[!] python/management/osx/shellb module not loaded")
-            
+
     def do_viewrepo(self, line):
         "View the contents of a repo. if none is specified, all files will be returned"
         repoName = line.strip()
@@ -2994,7 +2994,7 @@ class ListenersMenu(SubMenu):
 
     def do_launcher(self, line):
         "Generate an initial launcher for a listener."
-        
+
         parts = line.strip().split()
         if len(parts) != 2:
             print helpers.color("[!] Please enter 'launcher <language> <listenerName>'")
@@ -3389,7 +3389,7 @@ class ModuleMenu(SubMenu):
             _agent = ''
             if 'Agent' in self.module.options:
                 _agent = self.module.options['Agent']['Value']
-	    
+
 	        line = line.strip("*")
             module_menu = ModuleMenu(self.mainMenu, line, agent=_agent)
             module_menu.cmdloop()

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -423,6 +423,14 @@ class MainMenu(cmd.Cmd):
         pluginNames = [name for _, name, _ in pkgutil.walk_packages([pluginPath])]
         if pluginName in pluginNames:
             print(helpers.color("[*] Plugin {} found.".format(pluginName)))
+
+            message = "[*] Loading plugin {}".format(pluginName)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="empire")
+
             # 'self' is the mainMenu object
             plugins.load_plugin(self, pluginName)
         else:
@@ -665,10 +673,24 @@ class MainMenu(cmd.Cmd):
                         print helpers.color("[!] PowerShell is not installed and is required to use obfuscation, please install it first.")
                     else:
                         self.obfuscate = True
-                        print helpers.color("[*] Obfuscating all future powershell commands run on all agents.")
+
+                        message = "[*] Obfuscating all future powershell commands run on all agents."
+                        signal = json.dumps({
+                            'print': True,
+                            'message': message
+                        })
+                        dispatcher.send(signal, sender="empire")
+
                 elif parts[1].lower() == "false":
-                    print helpers.color("[*] Future powershell command run on all agents will not be obfuscated.")
                     self.obfuscate = False
+
+                    message = "[*] Future powershell commands run on all agents will not be obfuscated."
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message
+                    })
+                    dispatcher.send(signal, sender="empire")
+
                 else:
                     print helpers.color("[!] Valid options for obfuscate are 'true' or 'false'")
             elif parts[0].lower() == "obfuscate_command":
@@ -836,7 +858,13 @@ class MainMenu(cmd.Cmd):
             for file in files:
                 file = self.installPath + file
                 if reobfuscate or not helpers.is_obfuscated(file):
-                    print helpers.color("[*] Obfuscating " + os.path.basename(file) + "...")
+                    message = "[*] Obfuscating {}...".format(os.path.basename(file))
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message,
+                        'obfuscated_file': os.path.basename(file)
+                    })
+                    dispatcher.send(signal, sender="empire")
                 else:
                     print helpers.color("[*] " + os.path.basename(file) + " was already obfuscated. Not reobfuscating.")
                 helpers.obfuscate_module(file, self.obfuscateCommand, reobfuscate)
@@ -1200,6 +1228,15 @@ class AgentsMenu(SubMenu):
                 self.mainMenu.agents.set_agent_field_db('jitter', jitter, sessionID)
                 # task the agent
                 self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_SHELL', 'Set-Delay ' + str(delay) + ' ' + str(jitter))
+
+                # dispatch this event
+                message = "[*] Tasked agent to delay sleep/jitter {}/{}".format(delay, jitter)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
+
                 # update the agent log
                 msg = "Tasked agent to delay sleep/jitter %s/%s" % (delay, jitter)
                 self.mainMenu.agents.save_agent_log(sessionID, msg)
@@ -1219,6 +1256,15 @@ class AgentsMenu(SubMenu):
                 self.mainMenu.agents.set_agent_field_db('jitter', jitter, sessionID)
 
                 self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_SHELL', 'Set-Delay ' + str(delay) + ' ' + str(jitter))
+
+                # dispatch this event
+                message = "[*] Tasked agent to delay sleep/jitter {}/{}".format(delay, jitter)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
+
                 # update the agent log
                 msg = "Tasked agent to delay sleep/jitter %s/%s" % (delay, jitter)
                 self.mainMenu.agents.save_agent_log(sessionID, msg)
@@ -1245,6 +1291,15 @@ class AgentsMenu(SubMenu):
                 self.mainMenu.agents.set_agent_field_db('lost_limit', lostLimit, sessionID)
                 # task the agent
                 self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_SHELL', 'Set-LostLimit ' + str(lostLimit))
+
+                # dispatch this event
+                message = "[*] Tasked agent to change lost limit {}".format(lostLimit)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
+
                 # update the agent log
                 msg = "Tasked agent to change lost limit %s" % (lostLimit)
                 self.mainMenu.agents.save_agent_log(sessionID, msg)
@@ -1259,6 +1314,15 @@ class AgentsMenu(SubMenu):
                 self.mainMenu.agents.set_agent_field_db('lost_limit', lostLimit, sessionID)
 
                 self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_SHELL', 'Set-LostLimit ' + str(lostLimit))
+
+                # dispatch this event
+                message = "[*] Tasked agent to change lost limit {}".format(lostLimit)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
+
                 # update the agent log
                 msg = "Tasked agent to change lost limit %s" % (lostLimit)
                 self.mainMenu.agents.save_agent_log(sessionID, msg)
@@ -1286,6 +1350,16 @@ class AgentsMenu(SubMenu):
                 self.mainMenu.agents.set_agent_field_db('kill_date', date, sessionID)
                 # task the agent
                 self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_SHELL', "Set-KillDate " + str(date))
+
+                # dispatch this event
+                message = "[*] Tasked agent to set killdate to {}".format(date)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
+
+                # update the agent log
                 msg = "Tasked agent to set killdate to " + str(date)
                 self.mainMenu.agents.save_agent_log(sessionID, msg)
 
@@ -1299,6 +1373,15 @@ class AgentsMenu(SubMenu):
                 self.mainMenu.agents.set_agent_field_db('kill_date', date, sessionID)
                 # task the agent
                 self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_SHELL', "Set-KillDate " + str(date))
+
+                # dispatch this event
+                message = "[*] Tasked agent to set killdate to {}".format(date)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
+
                 # update the agent log
                 msg = "Tasked agent to set killdate to " + str(date)
                 self.mainMenu.agents.save_agent_log(sessionID, msg)
@@ -1327,6 +1410,16 @@ class AgentsMenu(SubMenu):
                 self.mainMenu.agents.set_agent_field_db('working_hours', hours, sessionID)
                 # task the agent
                 self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_SHELL', "Set-WorkingHours " + str(hours))
+
+                # dispatch this event
+                message = "[*] Tasked agent to set working hours to {}".format(hours)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
+
+                # update the agent log
                 msg = "Tasked agent to set working hours to %s" % (hours)
                 self.mainMenu.agents.save_agent_log(sessionID, msg)
 
@@ -1342,6 +1435,14 @@ class AgentsMenu(SubMenu):
                 self.mainMenu.agents.set_agent_field_db('working_hours', hours, sessionID)
                 # task the agent
                 self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_SHELL', "Set-WorkingHours " + str(hours))
+
+                # dispatch this event
+                message = "[*] Tasked agent to set working hours to {}".format(hours)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(sessionID))
 
                 # update the agent log
                 msg = "Tasked agent to set working hours to %s" % (hours)
@@ -1612,6 +1713,16 @@ class PowerShellAgentMenu(SubMenu):
                 shellcmd = ' '.join(parts)
                 # task the agent with this shell command
                 self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", shellcmd)
+
+                # dispatch this event
+                message = "[*] Tasked agent to run command {}".format(line)
+                signal = json.dumps({
+                    'print': False,
+                    'message': message,
+                    'command': line
+                })
+                dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
                 # update the agent log
                 msg = "Tasked agent to run command " + line
                 self.mainMenu.agents.save_agent_log(self.sessionID, msg)
@@ -1668,6 +1779,15 @@ class PowerShellAgentMenu(SubMenu):
             if choice.lower() == "y":
 
                 self.mainMenu.agents.add_agent_task_db(self.sessionID, 'TASK_EXIT')
+
+                # dispatch this event
+                message = "[*] Tasked agent to exit"
+                signal = json.dumps({
+                    'print': False,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
                 # update the agent log
                 self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to exit")
                 return True
@@ -1689,6 +1809,15 @@ class PowerShellAgentMenu(SubMenu):
         if len(parts) == 1:
             if parts[0] == '':
                 self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_GETJOBS")
+
+                # dispatch this event
+                message = "[*] Tasked agent to get running jobs"
+                signal = json.dumps({
+                    'print': False,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
                 # update the agent log
                 self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to get running jobs")
             else:
@@ -1696,6 +1825,15 @@ class PowerShellAgentMenu(SubMenu):
         elif len(parts) == 2:
             jobID = parts[1].strip()
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_STOPJOB", jobID)
+
+            # dispatch this event
+            message = "[*] Tasked agent to stop job {}".format(jobID)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             # update the agent log
             self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to stop job " + str(jobID))
 
@@ -1707,6 +1845,15 @@ class PowerShellAgentMenu(SubMenu):
         if len(parts) == 1:
             if parts[0] == '':
                 self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_GETDOWNLOADS")
+
+                # dispatch this event
+                message = "[*] Tasked agent to get downloads"
+                signal = json.dumps({
+                    'print': False,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
                 #update the agent log
                 self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to get downloads")
             else:
@@ -1714,6 +1861,15 @@ class PowerShellAgentMenu(SubMenu):
         elif len(parts) == 2:
             jobID = parts[1].strip()
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_STOPDOWNLOAD", jobID)
+
+            # dispatch this event
+            message = "[*] Tasked agent to stop download {}".format(jobID)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             #update the agent log
             self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to stop download " + str(jobID))
 
@@ -1733,6 +1889,15 @@ class PowerShellAgentMenu(SubMenu):
             self.mainMenu.agents.set_agent_field_db("jitter", jitter, self.sessionID)
 
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", "Set-Delay " + str(delay) + ' ' + str(jitter))
+
+            # dispatch this event
+            message = "[*] Tasked agent to delay sleep/jitter {}/{}".format(delay, jitter)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             # update the agent log
             msg = "Tasked agent to delay sleep/jitter " + str(delay) + "/" + str(jitter)
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
@@ -1748,6 +1913,15 @@ class PowerShellAgentMenu(SubMenu):
         # update this agent's information in the database
         self.mainMenu.agents.set_agent_field_db("lost_limit", lostLimit, self.sessionID)
         self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", "Set-LostLimit " + str(lostLimit))
+
+        # dispatch this event
+        message = "[*] Tasked agent to change lost limit {}".format(lostLimit)
+        signal = json.dumps({
+            'print': False,
+            'message': message
+        })
+        dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
         # update the agent log
         msg = "Tasked agent to change lost limit " + str(lostLimit)
         self.mainMenu.agents.save_agent_log(self.sessionID, msg)
@@ -1772,6 +1946,14 @@ class PowerShellAgentMenu(SubMenu):
 
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", command)
 
+            # dispatch this event
+            message = "[*] Tasked agent to kill process {}".format(process)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             msg = "Tasked agent to kill process: " + str(process)
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
 
@@ -1784,6 +1966,15 @@ class PowerShellAgentMenu(SubMenu):
 
         if date == "":
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", "Get-KillDate")
+
+            # dispatch this event
+            message = "[*] Tasked agent to get KillDate"
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to get KillDate")
 
         else:
@@ -1792,6 +1983,14 @@ class PowerShellAgentMenu(SubMenu):
 
             # task the agent
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", "Set-KillDate " + str(date))
+
+            # dispatch this event
+            message = "[*] Tasked agent to set KillDate to {}".format(date)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
 
             # update the agent log
             msg = "Tasked agent to set killdate to " + str(date)
@@ -1806,6 +2005,15 @@ class PowerShellAgentMenu(SubMenu):
 
         if hours == "":
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", "Get-WorkingHours")
+
+            # dispatch this event
+            message = "[*] Tasked agent to get working hours"
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to get working hours")
 
         else:
@@ -1815,6 +2023,14 @@ class PowerShellAgentMenu(SubMenu):
 
             # task the agent
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", "Set-WorkingHours " + str(hours))
+
+            # dispatch this event
+            message = "[*] Tasked agent to set working hours to {}".format(hours)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
 
             # update the agent log
             msg = "Tasked agent to set working hours to " + str(hours)
@@ -1829,6 +2045,15 @@ class PowerShellAgentMenu(SubMenu):
         if line != "":
             # task the agent with this shell command
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", "shell " + str(line))
+
+            # dispatch this event
+            message = "[*] Tasked agent to run shell command {}".format(line)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             # update the agent log
             msg = "Tasked agent to run shell command " + line
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
@@ -1839,6 +2064,15 @@ class PowerShellAgentMenu(SubMenu):
 
         # task the agent with this shell command
         self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SYSINFO")
+
+        # dispatch this event
+        message = "[*] Tasked agent to get system information"
+        signal = json.dumps({
+            'print': False,
+            'message': message
+        })
+        dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
         # update the agent log
         self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to get system information")
 
@@ -1850,6 +2084,15 @@ class PowerShellAgentMenu(SubMenu):
 
         if line != "":
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_DOWNLOAD", line)
+
+            # dispatch this event
+            message = "[*] Tasked agent to get system information"
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             # update the agent log
             msg = "Tasked agent to download " + line
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
@@ -1883,8 +2126,18 @@ class PowerShellAgentMenu(SubMenu):
                 if size > 1048576:
                     print helpers.color("[!] File size is too large. Upload limit is 1MB.")
                 else:
-                    # update the agent log with the filename and MD5
-                    print helpers.color("[*] Size of %s for upload: %s" %(uploadname, helpers.get_file_size(file_data)), color="green")
+                    # dispatch this event
+                    message = "[*] Tasked agent to upload {}, {}".format(uploadname, helpers.get_file_size(file_data))
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message,
+                        'file_name': uploadname,
+                        'file_md5': hashlib.md5(file_data).hexdigest(),
+                        'file_size': helpers.get_file_size(file_data)
+                    })
+                    dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
+                    # update the agent log
                     msg = "Tasked agent to upload %s : %s" % (parts[0], hashlib.md5(file_data).hexdigest())
                     self.mainMenu.agents.save_agent_log(self.sessionID, msg)
 
@@ -1912,6 +2165,16 @@ class PowerShellAgentMenu(SubMenu):
             # task the agent to important the script
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SCRIPT_IMPORT", script_data)
 
+            # dispatch this event
+            message = "[*] Tasked agent to import {}: {}".format(path, hashlib.md5(script_data).hexdigest())
+            signal = json.dumps({
+                'print': False,
+                'message': message,
+                'import_path': path,
+                'import_md5': hashlib.md5(script_data).hexdigest()
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             # update the agent log with the filename and MD5
             msg = "Tasked agent to import %s : %s" % (path, hashlib.md5(script_data).hexdigest())
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
@@ -1933,6 +2196,15 @@ class PowerShellAgentMenu(SubMenu):
 
         if command != "":
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SCRIPT_COMMAND", command)
+
+            # dispatch this event
+            message = "[*] Tasked agent {} to run {}".format(self.sessionID, command)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             msg = "[*] Tasked agent %s to run %s" % (self.sessionID, command)
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
 
@@ -1987,6 +2259,14 @@ class PowerShellAgentMenu(SubMenu):
 
                 # task the agent to update their profile
                 self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", updatecmd)
+
+                # dispatch this event
+                message = "[*] Tasked agent to update profile {}".format(profile)
+                signal = json.dumps({
+                    'print': False,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
 
                 # update the agent log
                 msg = "Tasked agent to update profile " + profile
@@ -2396,6 +2676,15 @@ class PythonAgentMenu(SubMenu):
             if choice.lower() == "y":
 
                 self.mainMenu.agents.add_agent_task_db(self.sessionID, 'TASK_EXIT')
+
+                # dispatch this event
+                message = "[*] Tasked agent to exit"
+                signal = json.dumps({
+                    'print': False,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
                 # update the agent log
                 self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to exit")
                 return True
@@ -2422,6 +2711,15 @@ class PythonAgentMenu(SubMenu):
                 self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", 'import os; os.chdir(os.pardir); print "Directory stepped down: %s"' % (line))
             else:
                 self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", 'import os; os.chdir("%s"); print "Directory changed to: %s"' % (line, line))
+
+            # dispatch this event
+            message = "[*] Tasked agent to change active directory to {}".format(line)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             # update the agent log
             msg = "Tasked agent to change active directory to: %s" % (line)
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
@@ -2435,6 +2733,15 @@ class PythonAgentMenu(SubMenu):
         if len(parts) == 1:
             if parts[0] == '':
                 self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_GETJOBS")
+
+                # dispatch this event
+                message = "[*] Tasked agent to get running jobs"
+                signal = json.dumps({
+                    'print': False,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
                 # update the agent log
                 self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to get running jobs")
             else:
@@ -2442,6 +2749,15 @@ class PythonAgentMenu(SubMenu):
         elif len(parts) == 2:
             jobID = parts[1].strip()
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_STOPJOB", jobID)
+
+            # dispatch this event
+            message = "[*] Tasked agent to get stop job {}".format(jobID)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             # update the agent log
             self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to stop job " + str(jobID))
 
@@ -2470,6 +2786,15 @@ class PythonAgentMenu(SubMenu):
         if delay == "":
             # task the agent to display the delay/jitter
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "global delay; global jitter; print 'delay/jitter = ' + str(delay)+'/'+str(jitter)")
+
+            # dispatch this event
+            message = "[*] Tasked agent to display delay/jitter"
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to display delay/jitter")
 
         elif len(parts) > 0 and parts[0] != "":
@@ -2483,6 +2808,14 @@ class PythonAgentMenu(SubMenu):
             self.mainMenu.agents.set_agent_field_db("jitter", jitter, self.sessionID)
 
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "global delay; global jitter; delay=%s; jitter=%s; print 'delay/jitter set to %s/%s'" % (delay, jitter, delay, jitter))
+
+            # dispatch this event
+            message = "[*] Tasked agent to delay sleep/jitter {}/{}".format(delay, jitter)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
 
             # update the agent log
             msg = "Tasked agent to delay sleep/jitter " + str(delay) + "/" + str(jitter)
@@ -2498,6 +2831,15 @@ class PythonAgentMenu(SubMenu):
         if lostLimit == "":
             # task the agent to display the lostLimit
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "global lostLimit; print 'lostLimit = ' + str(lostLimit)")
+
+            # dispatch this event
+            message = "[*] Tasked agent to display lost limit"
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to display lost limit")
         else:
             # update this agent's information in the database
@@ -2505,6 +2847,14 @@ class PythonAgentMenu(SubMenu):
 
             # task the agent with the new lostLimit
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "global lostLimit; lostLimit=%s; print 'lostLimit set to %s'"%(lostLimit, lostLimit))
+
+            # dispatch this event
+            message = "[*] Tasked agent to change lost limit {}".format(lostLimit)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
 
             # update the agent log
             msg = "Tasked agent to change lost limit " + str(lostLimit)
@@ -2521,6 +2871,15 @@ class PythonAgentMenu(SubMenu):
 
             # task the agent to display the killdate
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "global killDate; print 'killDate = ' + str(killDate)")
+
+            # dispatch this event
+            message = "[*] Tasked agent to display killDate"
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to display killDate")
         else:
             # update this agent's information in the database
@@ -2528,6 +2887,14 @@ class PythonAgentMenu(SubMenu):
 
             # task the agent with the new killDate
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "global killDate; killDate='%s'; print 'killDate set to %s'" % (killDate, killDate))
+
+            # dispatch this event
+            message = "[*] Tasked agent to set killDate to {}".format(killDate)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
 
             # update the agent log
             msg = "Tasked agent to set killdate to %s" %(killDate)
@@ -2542,6 +2909,15 @@ class PythonAgentMenu(SubMenu):
 
         if hours == "":
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "global workingHours; print 'workingHours = ' + str(workingHours)")
+
+            # dispatch this event
+            message = "[*] Tasked agent to get working hours"
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to get working hours")
 
         else:
@@ -2550,6 +2926,14 @@ class PythonAgentMenu(SubMenu):
 
             # task the agent with the new working hours
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "global workingHours; workingHours= '%s'"%(hours))
+
+            # dispatch this event
+            message = "[*] Tasked agent to set working hours to {}".format(hours)
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
 
             # update the agent log
             msg = "Tasked agent to set working hours to: %s" % (hours)
@@ -2564,6 +2948,16 @@ class PythonAgentMenu(SubMenu):
         if line != "":
             # task the agent with this shell command
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", str(line))
+
+            # dispatch this event
+            message = "[*] Tasked agent to run shell command: {}".format(line)
+            signal = json.dumps({
+                'print': False,
+                'message': message,
+                'command': line
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             # update the agent log
             msg = "Tasked agent to run shell command: %s" % (line)
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
@@ -2577,8 +2971,18 @@ class PythonAgentMenu(SubMenu):
         if line != "":
             # task the agent with this shell command
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", str(line))
+
+            # dispatch this event
+            message = "[*] Tasked agent to run Python command: {}".format(line)
+            signal = json.dumps({
+                'print': False,
+                'message': message,
+                'command': line
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             # update the agent log
-            msg = "Tasked agent to run Python command %s" % (line)
+            msg = "Tasked agent to run Python command: %s" % (line)
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
 
     def do_pythonscript(self, line):
@@ -2593,10 +2997,21 @@ class PythonAgentMenu(SubMenu):
             script = script.replace('\r\n', '\n')
             script = script.replace('\r', '\n')
             encScript = base64.b64encode(script)
-            msg = "[*] Tasked agent to execute python script: "+filename
-            print helpers.color(msg, color="green")
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SCRIPT_COMMAND", encScript)
+
+            # dispatch this event
+            message = "[*] Tasked agent to execute Python script: {}".format(filename)
+            signal = json.dumps({
+                'print': True,
+                'message': message,
+                'script_name': filename,
+                # note md5 is after replacements done on \r and \r\n above
+                'script_md5': hashlib.md5(script).hexdigest()
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             #update the agent log
+            msg = "[*] Tasked agent to execute python script: "+filename
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
         else:
             print helpers.color("[!] Please provide a valid path", color="red")
@@ -2607,6 +3022,15 @@ class PythonAgentMenu(SubMenu):
 
         # task the agent with this shell command
         self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SYSINFO")
+
+        # dispatch this event
+        message = "[*] Tasked agent to get system information"
+        signal = json.dumps({
+            'print': False,
+            'message': message
+        })
+        dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
         # update the agent log
         self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to get system information")
 
@@ -2618,6 +3042,16 @@ class PythonAgentMenu(SubMenu):
 
         if line != "":
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_DOWNLOAD", line)
+
+            # dispatch this event
+            message = "[*] Tasked agent to download: {}".format(line)
+            signal = json.dumps({
+                'print': False,
+                'message': message,
+                'download_filename': line
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             # update the agent log
             msg = "Tasked agent to download: %s" % (line)
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
@@ -2651,20 +3085,34 @@ class PythonAgentMenu(SubMenu):
                 if size > 1048576:
                     print helpers.color("[!] File size is too large. Upload limit is 1MB.")
                 else:
-                    print helpers.color("[*] Starting size of %s for upload: %s" %(uploadname, helpers.get_file_size(fileData)), color="green")
-                    msg = "Tasked agent to upload " + parts[0] + " : " + hashlib.md5(fileData).hexdigest()
+                    print helpers.color("[*] Original tasked size of %s for upload: %s" %(uploadname, helpers.get_file_size(fileData)), color="green")
+
+                    original_md5 = hashlib.md5(fileData).hexdigest()
                     # update the agent log with the filename and MD5
+                    msg = "Tasked agent to upload " + parts[0] + " : " + original_md5
                     self.mainMenu.agents.save_agent_log(self.sessionID, msg)
+
                     # compress data before we base64
                     c = compress.compress()
                     start_crc32 = c.crc32_data(fileData)
                     comp_data = c.comp_data(fileData, 9)
                     fileData = c.build_header(comp_data, start_crc32)
                     # get final file size
-                    print helpers.color("[*] Final tasked size of %s for upload: %s" %(uploadname, helpers.get_file_size(fileData)), color="green")
                     fileData = helpers.encode_base64(fileData)
                     # upload packets -> "filename | script data"
                     data = uploadname + "|" + fileData
+
+                    # dispatch this event
+                    message = "[*] Starting upload of {}, final size {}".format(uploadname, helpers.get_file_size(fileData))
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message,
+                        'upload_name': uploadname,
+                        'upload_md5': original_md5,
+                        'upload_size': helpers.get_file_size(fileData)
+                    })
+                    dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
                     self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_UPLOAD", data)
             else:
                 print helpers.color("[!] Please enter a valid file path to upload")
@@ -2705,6 +3153,15 @@ class PythonAgentMenu(SubMenu):
             module_menu = ModuleMenu(self.mainMenu, 'python/collection/osx/native_screenshot')
             print helpers.color(msg, color="green")
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
+
+            # dispatch this event
+            message = "[*] Tasked agent to take a screenshot"
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             module_menu.do_execute("")
         else:
             print helpers.color("[!] python/collection/osx/screenshot module not loaded")
@@ -2722,6 +3179,15 @@ class PythonAgentMenu(SubMenu):
             msg = "[*] Tasked agent to list directory contents of: "+str(module.options['Path']['Value'])
             print helpers.color(msg,color="green")
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
+
+            # dispatch this event
+            message = "[*] Tasked agent to list directory contents of: {}".format(module.options['Path']['Value'])
+            signal = json.dumps({
+                'print': False,
+                'message': message
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             module_menu.do_execute("")
 
         else:
@@ -2745,6 +3211,16 @@ except Exception as e:
 """ % (line)
             # task the agent with this shell command
             self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", str(cmd))
+
+            # dispatch this event
+            message = "[*] Tasked agent to cat file: {}".format(line)
+            signal = json.dumps({
+                'print': False,
+                'message': message,
+                'file_name': line
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             # update the agent log
             msg = "Tasked agent to cat file %s" % (line)
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
@@ -2754,6 +3230,16 @@ except Exception as e:
 
         command = "cwd = os.getcwd(); print cwd"
         self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", command)
+
+        # dispatch this event
+        message = "[*] Tasked agent to print current working directory"
+        signal = json.dumps({
+            'print': False,
+            'message': message,
+            'file_name': line
+        })
+        dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
         msg = "Tasked agent to print current working directory"
         self.mainMenu.agents.save_agent_log(self.sessionID, msg)
 
@@ -2762,6 +3248,16 @@ except Exception as e:
 
         command = "from AppKit import NSUserName; print str(NSUserName())"
         self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", command)
+
+        # dispatch this event
+        message = "[*] Tasked agent to print currently logged on user"
+        signal = json.dumps({
+            'print': False,
+            'message': message,
+            'file_name': line
+        })
+        dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
         msg = "Tasked agent to print currently logged on user"
         self.mainMenu.agents.save_agent_log(self.sessionID, msg)
 
@@ -2776,9 +3272,20 @@ except Exception as e:
             open_file = open(path, 'rb')
             module_data = open_file.read()
             open_file.close()
+
+            # dispatch this event
+            message = "[*] Tasked agent to import {}, md5: {}".format(path, hashlib.md5(module_data).hexdigest())
+            signal = json.dumps({
+                'print': True,
+                'message': message,
+                'import_path': path,
+                'import_md5': hashlib.md5(module_data).hexdigest()
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
             msg = "Tasked agent to import "+path+" : "+hashlib.md5(module_data).hexdigest()
-            print helpers.color("[*] "+msg, color="green")
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
+
             c = compress.compress()
             start_crc32 = c.crc32_data(module_data)
             comp_data = c.comp_data(module_data, 9)
@@ -2799,8 +3306,18 @@ except Exception as e:
 
             module.options['Agent']['Value'] = self.mainMenu.agents.get_agent_name_db(self.sessionID)
             module_menu = ModuleMenu(self.mainMenu, 'python/management/osx/shellb')
-            msg = "[*] Tasked agent to execute %s in the background" % (str(module.options['Path']['Value']))
-            print helpers.color(msg,color="green")
+
+            # dispatch this event
+            message = "[*] Tasked agent to execute {} in the background".format(module.options['Path']['Value'])
+            signal = json.dumps({
+                'print': True,
+                'message': message,
+                'options': module.options
+            })
+            dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
+            # update the agent log
+            msg = "Tasked agent to execute {} in the background".format(module.options['Path']['Value'])
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
             module_menu.do_execute("")
 
@@ -2810,14 +3327,35 @@ except Exception as e:
     def do_viewrepo(self, line):
         "View the contents of a repo. if none is specified, all files will be returned"
         repoName = line.strip()
+
+        # dispatch this event
+        message = "[*] Tasked agent to view repo contents: {}".format(repoName)
+        signal = json.dumps({
+            'print': True,
+            'message': message,
+            'repo_name': repoName
+        })
+        dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
+        # update the agent log
         msg = "[*] Tasked agent to view repo contents: " + repoName
-        print helpers.color(msg, color="green")
         self.mainMenu.agents.save_agent_log(self.sessionID, msg)
+
         self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_VIEW_MODULE", repoName)
 
     def do_removerepo(self, line):
         "Remove a repo"
         repoName = line.strip()
+
+        # dispatch this event
+        message = "[*] Tasked agent to remove repo: {}".format(repoName)
+        signal = json.dumps({
+            'print': True,
+            'message': message,
+            'repo_name': repoName
+        })
+        dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
+
         msg = "[*] Tasked agent to remove repo: "+repoName
         print helpers.color(msg, color="green")
         self.mainMenu.agents.save_agent_log(self.sessionID, msg)
@@ -2970,6 +3508,16 @@ class ListenersMenu(SubMenu):
                     stager.options['Obfuscate']['Value'] = "True"
                 else:
                     stager.options['Obfuscate']['Value'] = "False"
+
+                # dispatch this event
+                message = "[*] Generated launcher"
+                signal = json.dumps({
+                    'print': False,
+                    'message': message,
+                    'options': stager.options
+                })
+                dispatcher.send(signal, sender="empire")
+
                 print stager.generate()
             except Exception as e:
                 print helpers.color("[!] Error generating launcher: %s" % (e))
@@ -3082,6 +3630,16 @@ class ListenerMenu(SubMenu):
                 stager.options['ProxyCreds']['Value'] = listenerOptions['options']['ProxyCreds']['Value']
             except:
                 pass
+
+            # dispatch this event
+            message = "[*] Generated launcher"
+            signal = json.dumps({
+                'print': False,
+                'message': message,
+                'options': stager.options
+            })
+            dispatcher.send(signal, sender="empire")
+
             print stager.generate()
         except Exception as e:
             print helpers.color("[!] Error generating launcher: %s" % (e))
@@ -3370,14 +3928,6 @@ class ModuleMenu(SubMenu):
 
             if not moduleData or moduleData == "":
                 print helpers.color("[!] Error: module produced an empty script")
-                message = "[!] Error: module produced an empty script"
-                signal = json.dumps({
-                    'print': True,
-                    'message': message
-                })
-                dispatcher.send(signal, sender="agents/{}/{}".format(agentName, self.moduleName))
-                return
-
             try:
                 moduleData.decode('ascii')
             except UnicodeDecodeError:
@@ -3707,6 +4257,14 @@ class StagerMenu(SubMenu):
                 os.chmod(savePath, 777)
 
             print "\n" + helpers.color("[*] Stager output written out to: %s\n" % (savePath))
+            # dispatch this event
+            message = "[*] Generated stager"
+            signal = json.dumps({
+                'print': False,
+                'message': message,
+                'options': stager.options
+            })
+            dispatcher.send(signal, sender="empire")
         else:
             print stagerOutput
 

--- a/lib/common/events.py
+++ b/lib/common/events.py
@@ -15,7 +15,12 @@ from lib.common import db
 def handle_event(signal, sender):
     """ Puts all dispatched events into the DB """
     cur = db.cursor()
-    event_data = json.dumps({'signal': signal, 'sender': sender})
+    try:
+        signal_data = json.loads(signal)
+    except ValueError:
+        print(helpers.color("[!] Error: bad signal recieved {} from sender {}".format(signal, sender)))
+        return
+    event_data = json.dumps({'signal': signal_data, 'sender': sender})
     log_event(cur, 'user', 'dispatched_event', event_data, helpers.get_datetime())
     cur.close()
 

--- a/lib/common/events.py
+++ b/lib/common/events.py
@@ -14,7 +14,6 @@ from lib.common import db
 
 def handle_event(signal, sender):
     """ Puts all dispatched events into the DB """
-    # TODO get db cursor, insert events for all
     cur = db.cursor()
     event_data = json.dumps({'signal': signal, 'sender': sender})
     log_event(cur, 'user', 'dispatched_event', event_data, helpers.get_datetime())

--- a/lib/common/events.py
+++ b/lib/common/events.py
@@ -22,7 +22,9 @@ def handle_event(signal, sender):
 # Record all dispatched events
 dispatcher.connect(handle_event, sender=dispatcher.Any)
 
+################################################################################
 # Helper functions for logging common events
+################################################################################
 
 def agent_checkin(session_id, checkin_time):
     """
@@ -59,7 +61,7 @@ def agent_task(session_id, task_name, task_id, task):
     session_id - of an agent
     task_name  - a string (e.g. "TASK_EXIT", "TASK_CMD_WAIT", "TASK_SHELL") that
                  an agent is able to interpret as a command
-    task_id    - a unique ID for this task (usually an integer 0<id<65535)
+    task_id    - a unique ID for this task (usually an integer 0<=id<=65535)
     task       - the actual task definition string (e.g. for "TASK_SHELL" this
                  is the shell command to run)
     """
@@ -81,6 +83,29 @@ def agent_result(cur, session_id, response_name, task_id):
     response_data = json.dumps({'task_type': response_name})
     log_event(cur, session_id, "agent_result", response_data, helpers.get_datetime(), task_id)
     cur.close()
+
+def agent_delete(session_id):
+    """
+    Helper function for reporting an agent's deletion.
+
+    session_id - the agent's ID
+    """
+    cur = db.cursor()
+    data = json.dumps({})
+    log_event(cur, session_id, "agent_deleted", data, helpers.get_datetime())
+    cur.close()
+
+def agent_clear_tasks(session_id):
+    """
+    Helper function for reporting an agent's tasks have been cleared.
+
+    session_id - the agent's ID
+    """
+    cur = db.cursor()
+    data = json.dumps({})
+    log_event(cur, session_id, "agent_tasks_cleared", data, helpers.get_datetime())
+    cur.close()
+
 
 def log_event(cur, name, event_type, message, timestamp, task_id=None):
     """

--- a/lib/common/events.py
+++ b/lib/common/events.py
@@ -1,0 +1,112 @@
+"""
+Event handling system
+Every "major" event in Empire (loosely defined as everything you'd want to
+go into a report) is logged to the database. This file contains functions
+which help manage those events - logging them, fetching them, etc.
+"""
+
+import json
+
+from pydispatch import dispatcher
+
+import helpers
+from lib.common import db
+
+def handle_event(signal, sender):
+    """ Puts all dispatched events into the DB """
+    # TODO get db cursor, insert events for all
+    cur = db.cursor()
+    event_data = json.dumps({'signal': signal, 'sender': sender})
+    log_event(cur, 'user', 'dispatched_event', event_data, helpers.get_datetime())
+    cur.close()
+
+# Record all dispatched events
+dispatcher.connect(handle_event, sender=dispatcher.Any)
+
+# Helper functions for logging common events
+
+def agent_checkin(session_id, checkin_time):
+    """
+    Helper function for reporting agent checkins.
+
+    session_id   - of an agent
+    checkin_time - when that agent was first seen
+    """
+    cur = db.cursor()
+    checkin_data = json.dumps({'checkin_time': checkin_time})
+    log_event(cur, session_id, 'agent_checkin', checkin_data, helpers.get_datetime())
+    cur.close()
+
+def agent_rename(old_name, new_name):
+    """
+    Helper function for reporting agent name changes.
+
+    old_name - agent's old name
+    new_name - what the agent is being renamed to
+    """
+    # make sure to include new_name in there so it will persist if the agent
+    # is renamed again - that way we can still trace the trail back if needed
+    cur = db.cursor()
+    name_data = json.dumps({'old_name': old_name, 'new_name': new_name})
+    log_event(cur, new_name, 'agent_rename', name_data, helpers.get_datetime())
+    # rename all events left over using agent's old name
+    cur.execute("UPDATE reporting SET name=? WHERE name=?", [new_name, old_name])
+    cur.close()
+
+def agent_task(session_id, task_name, task_id, task):
+    """
+    Helper function for reporting agent taskings.
+
+    session_id - of an agent
+    task_name  - a string (e.g. "TASK_EXIT", "TASK_CMD_WAIT", "TASK_SHELL") that
+                 an agent is able to interpret as a command
+    task_id    - a unique ID for this task (usually an integer 0<id<65535)
+    task       - the actual task definition string (e.g. for "TASK_SHELL" this
+                 is the shell command to run)
+    """
+
+    cur = db.cursor()
+    task_data = json.dumps({'task_name': task_name, 'task': task})
+    log_event(cur, session_id, "agent_task", task_data, helpers.get_datetime(), task_id)
+    cur.close()
+
+def agent_result(cur, session_id, response_name, task_id):
+    """
+    Helper function for reporting agent task results.
+
+    Note that this doesn't store the actual result data; since it comes in
+    many forms (some large, and/or files, and so on) this event merely provides
+    all of the details you need to fetch the actual result from the database.
+    """
+
+    response_data = json.dumps({'task_type': response_name})
+    log_event(cur, session_id, "agent_result", response_data, helpers.get_datetime(), task_id)
+    cur.close()
+
+def log_event(cur, name, event_type, message, timestamp, task_id=None):
+    """
+    Log arbitrary events
+
+    cur        - a database connection object (such as that returned from
+                 `get_db_connection()`)
+    name       - some sort of identifier for the object the event pertains to
+                 (e.g. an agent or listener name)
+    event_type - the category of the event - agent_result, agent_task,
+                 agent_rename, etc. Ideally a succinct description of what the
+                 event actually is.
+    message    - the body of the event, WHICH MUST BE JSON, describing any
+                 pertinent details of the event
+    timestamp  - when the event occurred
+    task_id    - the ID of the task this event is in relation to. Enables quick
+                 queries of an agent's task and its result together.
+    """
+    cur.execute(
+        "INSERT INTO reporting (name, event_type, message, time_stamp, taskID) VALUES (?,?,?,?,?)",
+        (
+            name,
+            event_type,
+            message,
+            timestamp,
+            task_id
+        )
+    )

--- a/lib/common/events.py
+++ b/lib/common/events.py
@@ -9,33 +9,7 @@ import json
 
 from pydispatch import dispatcher
 
-import helpers
-from lib.common import db
-
-def handle_event(signal, sender):
-    """ Puts all dispatched events into the DB """
-    cur = db.cursor()
-    try:
-        signal_data = json.loads(signal)
-    except ValueError:
-        print(helpers.color("[!] Error: bad signal recieved {} from sender {}".format(signal, sender)))
-        return
-
-    # this should probably be set in the event itselfd but we can check
-    # here (and for most the time difference won't matter so it's fine)
-    if 'timestamp' not in signal_data:
-        signal_data['timestamp'] = helpers.get_datetime()
-
-    task_id = None
-    if 'task_id' in signal_data:
-        task_id = signal_data['task_id']
-
-    event_data = json.dumps({'signal': signal_data, 'sender': sender})
-    log_event(cur, sender, 'dispatched_event', json.dumps(signal_data), signal_data['timestamp'], task_id=task_id)
-    cur.close()
-
-# Record all dispatched events
-dispatcher.connect(handle_event, sender=dispatcher.Any)
+#from lib.common import db # used in the disabled TODO below
 
 ################################################################################
 # Helper functions for logging common events

--- a/lib/common/events.py
+++ b/lib/common/events.py
@@ -20,6 +20,12 @@ def handle_event(signal, sender):
     except ValueError:
         print(helpers.color("[!] Error: bad signal recieved {} from sender {}".format(signal, sender)))
         return
+
+    # this should probably be set in the event itselfd but we can check
+    # here (and for most the time difference won't matter so it's fine)
+    if 'timestamp' not in signal_data:
+        signal_data['timestamp'] = helpers.get_datetime()
+
     event_data = json.dumps({'signal': signal_data, 'sender': sender})
     log_event(cur, 'user', 'dispatched_event', event_data, helpers.get_datetime())
     cur.close()

--- a/lib/common/http.py
+++ b/lib/common/http.py
@@ -3,7 +3,7 @@
 HTTP related methods used by Empire.
 
 Includes URI validation/checksums, as well as the base
-http server (EmpireServer) and its modified request 
+http server (EmpireServer) and its modified request
 handler (RequestHandler).
 
 These are the first places URI requests are processed.
@@ -14,6 +14,7 @@ from BaseHTTPServer import BaseHTTPRequestHandler
 import BaseHTTPServer, threading, ssl, os, string, random
 from pydispatch import dispatcher
 import re
+import json
 
 # Empire imports
 import encryption
@@ -94,7 +95,17 @@ class RequestHandler(BaseHTTPRequestHandler):
                     name, sessionID = part.split("=", 1)
 
         # fire off an event for this GET (for logging)
-        dispatcher.send("[*] "+resource+" requested from "+str(sessionID)+" at "+clientIP, sender="HttpHandler")
+        message = "[*] {resource} requested from {session_id} at {client_ip}".format(
+            resource=resource,
+            session_id=sessionID,
+            client_ip=clientIP
+        )
+
+        signal = json.dumps({
+            'print': True,
+            'message': message
+        })
+        dispatcher.send(signal, sender="empire")
 
         # get the appropriate response from the agent handler
         (code, responsedata) = self.server.agents.process_get(self.server.server_port, clientIP, sessionID, resource)
@@ -122,7 +133,17 @@ class RequestHandler(BaseHTTPRequestHandler):
                     name, sessionID = part.split("=", 1)
 
         # fire off an event for this POST (for logging)
-        dispatcher.send("[*] Post to "+resource+" from "+str(sessionID)+" at "+clientIP, sender="HttpHandler")
+        message = "[*] Post to {resource} from {session_id} at {client_ip}".format(
+            resource=resource,
+            session_id=sessionID,
+            client_ip=clientIP
+        )
+
+        signal = json.dumps({
+            'print': True,
+            'message': message
+        })
+        dispatcher.send(signal, sender="empire")
 
         # read in the length of the POST data
         if self.headers.getheader('content-length'):
@@ -138,12 +159,12 @@ class RequestHandler(BaseHTTPRequestHandler):
             self.wfile.write(responsedata)
             self.wfile.flush()
         # self.wfile.close() # causes an error with HTTP comms
-    
+
     # supress all the stupid default stdout/stderr output
     def log_message(*arg):
         pass
 
- 
+
 class EmpireServer(threading.Thread):
     """
     Version of a simple HTTP[S] Server with specifiable port and
@@ -162,7 +183,7 @@ class EmpireServer(threading.Thread):
             self.server = None
 
             self.server = BaseHTTPServer.HTTPServer((lhost, int(port)), RequestHandler)
-            
+
             # pass the agent handler object along for the RequestHandler
             self.server.agents = handler
 
@@ -176,14 +197,25 @@ class EmpireServer(threading.Thread):
 
                 self.server.socket = ssl.wrap_socket(self.server.socket, certfile=cert, server_side=True)
 
-                dispatcher.send("[*] Initializing HTTPS server on "+str(port), sender="EmpireServer")
+                message = "[*] Initializing HTTPS server on {port}".format(port=port)
             else:
-                dispatcher.send("[*] Initializing HTTP server on "+str(port), sender="EmpireServer")
+                message = "[*] Initializing HTTP server on {port}".format(port=port)
+
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="empire")
 
         except Exception as e:
             self.success = False
             # shoot off an error if the listener doesn't stand up
-            dispatcher.send("[!] Error starting listener on port "+str(port)+": "+str(e), sender="EmpireServer")
+            message = "[!] Error starting listener on port {}: {}".format(port, e)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="empire")
 
 
     def base_server(self):

--- a/lib/common/listeners.py
+++ b/lib/common/listeners.py
@@ -12,6 +12,7 @@ import os
 import pickle
 import hashlib
 import copy
+import json
 
 from pydispatch import dispatcher
 

--- a/lib/common/listeners.py
+++ b/lib/common/listeners.py
@@ -13,6 +13,8 @@ import pickle
 import hashlib
 import copy
 
+from pydispatch import dispatcher
+
 class Listeners:
     """
     Listener handling class.
@@ -185,7 +187,7 @@ class Listeners:
         i = 1
         while name in self.activeListeners.keys():
             name = "%s%s" % (nameBase, i)
-        
+
         listenerObject.options['Name']['Value'] = name
 
         try:
@@ -193,13 +195,21 @@ class Listeners:
             success = listenerObject.start(name=name)
 
             if success:
-                print helpers.color('[+] Listener successfully started!')
                 listenerOptions = copy.deepcopy(listenerObject.options)
                 self.activeListeners[name] = {'moduleName': moduleName, 'options':listenerOptions}
                 pickledOptions = pickle.dumps(listenerObject.options)
                 cur = self.conn.cursor()
                 cur.execute("INSERT INTO listeners (name, module, listener_category, options) VALUES (?,?,?,?)", [name, moduleName, category, pickledOptions])
                 cur.close()
+
+                # dispatch this event
+                message = "[+] Listener successfully started!"
+                signal = json.dumps({
+                    'print': True,
+                    'message': message,
+                    'listener_options': listenerOptions
+                })
+                dispatcher.send(signal, sender="listeners/{}/{}".format(moduleName, name))
             else:
                 print helpers.color('[!] Listener failed to start!')
 
@@ -246,9 +256,16 @@ class Listeners:
                     success = listenerModule.start(name=listenerName)
 
                 if success:
-                    print helpers.color('[+] Listener successfully started!')
                     listenerOptions = copy.deepcopy(listenerModule.options)
                     self.activeListeners[listenerName] = {'moduleName': moduleName, 'options':listenerOptions}
+                    # dispatch this event
+                    message = "[+] Listener successfully started!"
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message,
+                        'listener_options': listenerOptions
+                    })
+                    dispatcher.send(signal, sender="listeners/{}/{}".format(moduleName, listenerName))
                 else:
                     print helpers.color('[!] Listener failed to start!')
 
@@ -267,7 +284,7 @@ class Listeners:
 
         To kill all listeners, use listenerName == 'all'
         """
- 
+
         if listenerName.lower() == 'all':
             listenerNames = self.activeListeners.keys()
         else:
@@ -287,7 +304,7 @@ class Listeners:
                 cur.execute("DELETE FROM listeners WHERE name=?", [listenerName])
                 cur.close()
                 continue
-                
+
             self.shutdown_listener(listenerName)
 
             # remove the listener from the database
@@ -326,6 +343,14 @@ class Listeners:
 
             # remove the listener object from the internal cache
             del self.activeListeners[listenerName]
+
+            # dispatch this event
+            message = "[*] Listener {} killed".format(listenerName)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="listeners/{}/{}".format(activeListenerModuleName, listenerName))
 
 
     def is_listener_valid(self, name):

--- a/lib/common/packets.py
+++ b/lib/common/packets.py
@@ -13,11 +13,11 @@ HMACc = first 10 bytes of a SHA256 HMAC using the client's session key
 
     Routing Packet:
     +---------+-------------------+--------------------------+
-    | RC4 IV  | RC4s(RoutingData) | AESc(client packet data) | ... 
+    | RC4 IV  | RC4s(RoutingData) | AESc(client packet data) | ...
     +---------+-------------------+--------------------------+
     |    4    |         16        |        RC4 length        |
     +---------+-------------------+--------------------------+
-    
+
     RC4s(RoutingData):
     +-----------+------+------+-------+--------+
     | SessionID | Lang | Meta | Extra | Length |
@@ -44,12 +44,12 @@ HMACc = first 10 bytes of a SHA256 HMAC using the client's session key
     +------+--------+--------------------+--------------------+-----------+
     |  2   |   4    |         2          |    2     |    2    | <Length>  |
     +------+--------+--------------------+----------+---------+-----------+
-    
+
     type = packet type
     total # of packets = number of total packets in the transmission
     Packet # = where the packet fits in the transmission
     Task ID = links the tasking to results for deconflict on server side
-    
+
 
     Client *_SAVE packets have the sub format:
 
@@ -64,6 +64,7 @@ import base64
 import os
 import hashlib
 import hmac
+import json
 from pydispatch import dispatcher
 
 # Empire imports
@@ -204,7 +205,13 @@ def parse_result_packet(packet, offset=0):
         remainingData = packet[12+offset+length:]
         return (PACKET_IDS[responseID], totalPacket, packetNum, taskID, length, data, remainingData)
     except Exception as e:
-        dispatcher.send("[*] parse_result_packet(): exception: %s" % (e), sender='Packets')
+        message = "[!] parse_result_packet(): exception: {}".format(e)
+        signal = json.dumps({
+            'print': True,
+            'message': message
+        })
+        dispatcher.send(signal, sender="empire")
+
         return (None, None, None, None, None, None, None)
 
 
@@ -244,11 +251,11 @@ def parse_routing_packet(stagingKey, data):
     Routing packet format:
 
         +---------+-------------------+--------------------------+
-        | RC4 IV  | RC4s(RoutingData) | AESc(client packet data) | ... 
+        | RC4 IV  | RC4s(RoutingData) | AESc(client packet data) | ...
         +---------+-------------------+--------------------------+
         |    4    |         16        |        RC4 length        |
         +---------+-------------------+--------------------------+
-        
+
         RC4s(RoutingData):
         +-----------+------+------+-------+--------+
         | SessionID | Lang | Meta | Extra | Length |
@@ -278,7 +285,12 @@ def parse_routing_packet(stagingKey, data):
                 # B == 1 byte unsigned char, H == 2 byte unsigned short, L == 4 byte unsigned long
                 (language, meta, additional, length) = struct.unpack("=BBHL", routingPacket[8:])
                 if length < 0:
-                    dispatcher.send('[*] parse_agent_data(): length in decoded rc4 packet is < 0', sender='Packets')
+                    message = "[*] parse_agent_data(): length in decoded rc4 packet is < 0"
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message
+                    })
+                    dispatcher.send(signal, sender="empire")
                     encData = None
                 else:
                     encData = data[(20+offset):(20+offset+length)]
@@ -295,11 +307,21 @@ def parse_routing_packet(stagingKey, data):
             return results
 
         else:
-            dispatcher.send("[*] parse_agent_data() data length incorrect: %s" % (len(data)), sender='Packets')
+            message = "[*] parse_agent_data() data length incorrect: {}".format(len(data))
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="empire")
             return None
 
     else:
-        dispatcher.send("[*] parse_agent_data() data is None", sender='Packets')
+        message = "[*] parse_agent_data() data is None"
+        signal = json.dumps({
+            'print': True,
+            'message': message
+        })
+        dispatcher.send(signal, sender="empire")
         return None
 
 
@@ -312,11 +334,11 @@ def build_routing_packet(stagingKey, sessionID, language, meta="NONE", additiona
 
         Routing Packet:
         +---------+-------------------+--------------------------+
-        | RC4 IV  | RC4s(RoutingData) | AESc(client packet data) | ... 
+        | RC4 IV  | RC4s(RoutingData) | AESc(client packet data) | ...
         +---------+-------------------+--------------------------+
         |    4    |         16        |        RC4 length        |
         +---------+-------------------+--------------------------+
-        
+
         RC4s(RoutingData):
         +-----------+------+------+-------+--------+
         | SessionID | Lang | Meta | Extra | Length |

--- a/lib/common/stagers.py
+++ b/lib/common/stagers.py
@@ -99,7 +99,7 @@ class Stagers:
         activeListener = self.mainMenu.listeners.activeListeners[listenerName]
 
         launcherCode = self.mainMenu.listeners.loadedListeners[activeListener['moduleName']].generate_launcher(encode=encode, obfuscate=obfuscate, obfuscationCommand=obfuscationCommand, userAgent=userAgent, proxy=proxy, proxyCreds=proxyCreds, stagerRetries=stagerRetries, language=language, listenerName=listenerName, safeChecks=safeChecks)
-        
+
         if launcherCode:
             return launcherCode
 
@@ -231,9 +231,6 @@ class Stagers:
         """
         Generates an application. The embedded executable is a macho binary with the python interpreter.
         """
-
-        
-
         MH_EXECUTE = 2
 
         if Arch == 'x64':
@@ -365,8 +362,8 @@ class Stagers:
             f.close()
             os.remove("/tmp/launcher.zip")
             return zipbundle
-        
-            
+
+
         else:
             print helpers.color("[!] Unable to patch application")
 
@@ -453,7 +450,7 @@ class Stagers:
                 raise
             else:
                 pass
-        
+
         file = open(jarpath+'Run.java','w')
         file.write(javacode)
         file.close()
@@ -469,7 +466,7 @@ class Stagers:
         jarfile.close()
         os.remove('Run.jar')
 
-        return jar 
+        return jar
 
 
     def generate_upload(self, file, path):

--- a/lib/listeners/dbx.py
+++ b/lib/listeners/dbx.py
@@ -3,6 +3,7 @@ import random
 import os
 import time
 import copy
+import json
 import dropbox
 # from dropbox.exceptions import ApiError, AuthError
 # from dropbox.files import FileMetadata, FolderMetadata, CreateFolderError
@@ -801,7 +802,14 @@ def send_message(packets=None):
             try:
                 md, res = dbx.files_download(path)
             except dropbox.exceptions.HttpError as err:
-                dispatcher.send("[!] Error download data from '%s' : %s" % (path, err), sender="listeners/dropbox")
+                listenerName = self.options['Name']['Value']
+                message = "[!] Error downloading data from '{}' : {}".format(path, err)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
+
                 return None
             return res.content
 
@@ -810,14 +818,26 @@ def send_message(packets=None):
             try:
                 dbx.files_upload(data, path)
             except dropbox.exceptions.ApiError:
-                dispatcher.send("[!] Error uploading data to '%s'" % (path), sender="listeners/dropbox")
+                listenerName = self.options['Name']['Value']
+                message = "[!] Error uploading data to '{}'".format(path)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
 
         def delete_file(dbx, path):
             # helper to delete a file at the given path
             try:
                 dbx.files_delete(path)
             except dropbox.exceptions.ApiError:
-                dispatcher.send("[!] Error deleting data at '%s'" % (path), sender="listeners/dropbox")
+                listenerName = self.options['Name']['Value']
+                message = "[!] Error deleting data at '{}'".format(path)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
 
 
         # make a copy of the currently set listener options for later stager/agent generation
@@ -845,15 +865,33 @@ def send_message(packets=None):
         try:
             dbx.files_create_folder(stagingFolder)
         except dropbox.exceptions.ApiError:
-            dispatcher.send("[*] Dropbox folder '%s' already exists" % (stagingFolder), sender="listeners/dropbox")
+            listenerName = self.options['Name']['Value']
+            message = "[*] Dropbox folder '{}' already exists".format(stagingFolder)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
         try:
             dbx.files_create_folder(taskingsFolder)
         except dropbox.exceptions.ApiError:
-            dispatcher.send("[*] Dropbox folder '%s' already exists" % (taskingsFolder), sender="listeners/dropbox")
+            listenerName = self.options['Name']['Value']
+            message = "[*] Dropbox folder '{}' already exists".format(taskingsFolder)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
         try:
             dbx.files_create_folder(resultsFolder)
         except dropbox.exceptions.ApiError:
-            dispatcher.send("[*] Dropbox folder '%s' already exists" % (resultsFolder), sender="listeners/dropbox")
+            listenerName = self.options['Name']['Value']
+            message = "[*] Dropbox folder '{}' already exists".format(resultsFolder)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
 
         # upload the stager.ps1 code
         stagerCodeps = self.generate_stager(listenerOptions=listenerOptions, language='powershell')
@@ -884,7 +922,13 @@ def send_message(packets=None):
                         try:
                             md, res = dbx.files_download(fileName)
                         except dropbox.exceptions.HttpError as err:
-                            dispatcher.send("[!] Error download data from '%s' : %s" % (fileName, err), sender="listeners/dropbox")
+                            listenerName = self.options['Name']['Value']
+                            message = "[!] Error downloading data from '{}' : {}".format(fileName, err)
+                            signal = json.dumps({
+                                'print': True,
+                                'message': message
+                            })
+                            dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
                             continue
                         stageData = res.content
 
@@ -895,19 +939,43 @@ def send_message(packets=None):
                                 try:
                                     dbx.files_delete(fileName)
                                 except dropbox.exceptions.ApiError:
-                                    dispatcher.send("[!] Error deleting data at '%s'" % (fileName), sender="listeners/dropbox")
+                                    listenerName = self.options['Name']['Value']
+                                    message = "[!] Error deleting data at '{}'".format(fileName)
+                                    signal = json.dumps({
+                                        'print': True,
+                                        'message': message
+                                    })
+                                    dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
                                 try:
                                     stageName = "%s/%s_2.txt" % (stagingFolder, sessionID)
-                                    dispatcher.send("[*] Uploading key negotiation part 2 to %s for %s" % (stageName, sessionID), sender='listeners/dbx')
+                                    listenerName = self.options['Name']['Value']
+                                    message = "[*] Uploading key negotiation part 2 to {} for {}".format(stageName, sessionID)
+                                    signal = json.dumps({
+                                        'print': True,
+                                        'message': message
+                                    })
+                                    dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
                                     dbx.files_upload(results, stageName)
                                 except dropbox.exceptions.ApiError:
-                                    dispatcher.send("[!] Error uploading data to '%s'" % (stageName), sender="listeners/dropbox")
+                                    listenerName = self.options['Name']['Value']
+                                    message = "[!] Error uploading data to '{}'".format(stageName)
+                                    signal = json.dumps({
+                                        'print': True,
+                                        'message': message
+                                    })
+                                    dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
 
                     if stage == '3':
                         try:
                             md, res = dbx.files_download(fileName)
                         except dropbox.exceptions.HttpError as err:
-                            dispatcher.send("[!] Error download data from '%s' : %s" % (fileName, err), sender="listeners/dropbox")
+                            listenerName = self.options['Name']['Value']
+                            message = "[!] Error downloading data from '{}' : {}".format(fileName, err)
+                            signal = json.dumps({
+                                'print': True,
+                                'message': message
+                            })
+                            dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
                             continue
                         stageData = res.content
 
@@ -917,18 +985,36 @@ def send_message(packets=None):
                             for (language, results) in dataResults:
                                 if results.startswith('STAGE2'):
                                     sessionKey = self.mainMenu.agents.agents[sessionID]['sessionKey']
-                                    dispatcher.send("[*] Sending agent (stage 2) to %s through Dropbox" % (sessionID), sender='listeners/dbx')
+                                    listenerName = self.options['Name']['Value']
+                                    message = "[*] Sending agent (stage 2) to {} through Dropbox".format(sessionID)
+                                    signal = json.dumps({
+                                        'print': True,
+                                        'message': message
+                                    })
+                                    dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
 
                                     try:
                                         dbx.files_delete(fileName)
                                     except dropbox.exceptions.ApiError:
-                                        dispatcher.send("[!] Error deleting data at '%s'" % (fileName), sender="listeners/dropbox")
+                                        listenerName = self.options['Name']['Value']
+                                        message = "[!] Error deleting data at '{}'".format(fileName)
+                                        signal = json.dumps({
+                                            'print': True,
+                                            'message': message
+                                        })
+                                        dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
 
                                     try:
                                         fileName2 = fileName.replace("%s_3.txt" % (sessionID), "%s_2.txt" % (sessionID))
                                         dbx.files_delete(fileName2)
                                     except dropbox.exceptions.ApiError:
-                                        dispatcher.send("[!] Error deleting data at '%s'" % (fileName2), sender="listeners/dropbox")
+                                        listenerName = self.options['Name']['Value']
+                                        message = "[!] Error deleting data at '{}'".format(fileName2)
+                                        signal = json.dumps({
+                                            'print': True,
+                                            'message': message
+                                        })
+                                        dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
 
                                     # step 6 of negotiation -> server sends patched agent.ps1/agent.py
                                     agentCode = self.generate_agent(language=language, listenerOptions=listenerOptions)
@@ -936,10 +1022,22 @@ def send_message(packets=None):
 
                                     try:
                                         stageName = "%s/%s_4.txt" % (stagingFolder, sessionID)
-                                        dispatcher.send("[*] Uploading key negotiation part 4 (agent) to %s for %s" % (stageName, sessionID), sender='listeners/dbx')
+                                        listenerName = self.options['Name']['Value']
+                                        message = "[*] Uploading key negotiation part 4 (agent) to {} for {}".format(stageName, sessionID)
+                                        signal = json.dumps({
+                                            'print': True,
+                                            'message': message
+                                        })
+                                        dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
                                         dbx.files_upload(returnResults, stageName)
                                     except dropbox.exceptions.ApiError:
-                                        dispatcher.send("[!] Error uploading data to '%s'" % (stageName), sender="listeners/dropbox")
+                                        listenerName = self.options['Name']['Value']
+                                        message = "[!] Error uploading data to '{}'".format(stageName)
+                                        signal = json.dumps({
+                                            'print': True,
+                                            'message': message
+                                        })
+                                        dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
 
 
             # get any taskings applicable for agents linked to this listener
@@ -961,22 +1059,47 @@ def send_message(packets=None):
                         if existingData:
                             taskingData = taskingData + existingData
 
-                        dispatcher.send("[*] Uploading agent tasks for %s to %s" % (sessionID, taskingFile), sender='listeners/dbx')
+                        listenerName = self.options['Name']['Value']
+                        message = "[*] Uploading agent tasks for {} to {}".format(sessionID, taskingFile)
+                        signal = json.dumps({
+                            'print': True,
+                            'message': message
+                        })
+                        dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
+
                         dbx.files_upload(taskingData, taskingFile, mode=dropbox.files.WriteMode.overwrite)
                     except dropbox.exceptions.ApiError as e:
-                        dispatcher.send("[!] Error uploading agent tasks for %s to %s : %s" % (sessionID, taskingFile, e), sender="listeners/dropbox")
+                        listenerName = self.options['Name']['Value']
+                        message = "[!] Error uploading agent tasks for {} to {} : {}".format(sessionID, taskingFile, e)
+                        signal = json.dumps({
+                            'print': True,
+                            'message': message
+                        })
+                        dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
 
             # check for any results returned
             for match in dbx.files_search(resultsFolder, "*.txt").matches:
                 fileName = str(match.metadata.path_display)
                 sessionID = fileName.split('/')[-1][:-4]
 
-                dispatcher.send("[*] Downloading data for '%s' from %s" % (sessionID, fileName), sender="listeners/dropbox")
+                listenerName = self.options['Name']['Value']
+                message = "[*] Downloading data for '{}' from {}".format(sessionID, fileName)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
 
                 try:
                     md, res = dbx.files_download(fileName)
                 except dropbox.exceptions.HttpError as err:
-                    dispatcher.send("[!] Error download data from '%s' : %s" % (fileName, err), sender="listeners/dropbox")
+                    listenerName = self.options['Name']['Value']
+                    message = "[!] Error download data from '{}' : {}".format(fileName, err)
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message
+                    })
+                    dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
                     continue
 
                 responseData = res.content
@@ -984,7 +1107,13 @@ def send_message(packets=None):
                 try:
                     dbx.files_delete(fileName)
                 except dropbox.exceptions.ApiError:
-                    dispatcher.send("[!] Error deleting data at '%s'" % (fileName), sender="listeners/dropbox")
+                    listenerName = self.options['Name']['Value']
+                    message = "[!] Error deleting data at '{}'".format(fileName)
+                    signal = json.dumps({
+                        'print': True,
+                        'message': message
+                    })
+                    dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
 
                 self.mainMenu.agents.handle_agent_data(stagingKey, responseData, listenerOptions)
 

--- a/lib/listeners/dbx.py
+++ b/lib/listeners/dbx.py
@@ -868,7 +868,7 @@ def send_message(packets=None):
             listenerName = self.options['Name']['Value']
             message = "[*] Dropbox folder '{}' already exists".format(stagingFolder)
             signal = json.dumps({
-                'print': True,
+                'print': False,
                 'message': message
             })
             dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
@@ -878,7 +878,7 @@ def send_message(packets=None):
             listenerName = self.options['Name']['Value']
             message = "[*] Dropbox folder '{}' already exists".format(taskingsFolder)
             signal = json.dumps({
-                'print': True,
+                'print': False,
                 'message': message
             })
             dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))
@@ -888,7 +888,7 @@ def send_message(packets=None):
             listenerName = self.options['Name']['Value']
             message = "[*] Dropbox folder '{}' already exists".format(resultsFolder)
             signal = json.dumps({
-                'print': True,
+                'print': False,
                 'message': message
             })
             dispatcher.send(signal, sender="listeners/dropbox/{}".format(listenerName))

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -968,7 +968,7 @@ def send_message(packets=None):
             listenerName = self.options['Name']['Value']
             message = "[*] GET request for {}/{} from {}".format(request.host, request_uri, clientIP)
             signal = json.dumps({
-                'print': True,
+                'print': False,
                 'message': message
             })
             dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
@@ -983,7 +983,7 @@ def send_message(packets=None):
                         listenerName = self.options['Name']['Value']
                         message = "[*] GET cookie value from {} : {}".format(clientIP, cookie)
                         signal = json.dumps({
-                            'print': True,
+                            'print': False,
                             'message': message
                         })
                         dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
@@ -1036,9 +1036,9 @@ def send_message(packets=None):
                             else:
                                 # actual taskings
                                 listenerName = self.options['Name']['Value']
-                                message = "[*] Agent from %s retrieved taskings".format(clientIP)
+                                message = "[*] Agent from {} retrieved taskings".format(clientIP)
                                 signal = json.dumps({
-                                    'print': True,
+                                    'print': False,
                                     'message': message
                                 })
                                 dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
@@ -1073,7 +1073,7 @@ def send_message(packets=None):
             listenerName = self.options['Name']['Value']
             message = "[*] POST request data length from {} : {}".format(clientIP, len(requestData))
             signal = json.dumps({
-                'print': True,
+                'print': False,
                 'message': message
             })
             dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
@@ -1125,7 +1125,7 @@ def send_message(packets=None):
                             return make_response(self.default_response(), 404)
                         elif results == 'VALID':
                             listenerName = self.options['Name']['Value']
-                            message = "[*] Valid results return by {}".format(clientIP)
+                            message = "[*] Valid results returned by {}".format(clientIP)
                             signal = json.dumps({
                                 'print': True,
                                 'message': message

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -6,6 +6,7 @@ import os
 import ssl
 import time
 import copy
+import json
 import sys
 from pydispatch import dispatcher
 from flask import Flask, request, make_response, send_from_directory
@@ -909,7 +910,13 @@ def send_message(packets=None):
             Before every request, check if the IP address is allowed.
             """
             if not self.mainMenu.agents.is_ip_allowed(request.remote_addr):
-                dispatcher.send("[!] %s on the blacklist/not on the whitelist requested resource" % (request.remote_addr), sender="listeners/http")
+                listenerName = self.options['Name']['Value']
+                message = "[!] {} on the blacklist/not on the whitelist requested resource".format(request.remote_addr)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
                 return make_response(self.default_response(), 404)
 
 
@@ -956,9 +963,16 @@ def send_message(packets=None):
             This is used during the first step of the staging process,
             and when the agent requests taskings.
             """
-
             clientIP = request.remote_addr
-            dispatcher.send("[*] GET request for %s/%s from %s" % (request.host, request_uri, clientIP), sender='listeners/http')
+
+            listenerName = self.options['Name']['Value']
+            message = "[*] GET request for {}/{} from {}".format(request.host, request_uri, clientIP)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
+
             routingPacket = None
             cookie = request.headers.get('Cookie')
             if cookie and cookie != '':
@@ -966,7 +980,13 @@ def send_message(packets=None):
                     # see if we can extract the 'routing packet' from the specified cookie location
                     # NOTE: this can be easily moved to a paramter, another cookie value, etc.
                     if 'session' in cookie:
-                        dispatcher.send("[*] GET cookie value from %s : %s" % (clientIP, cookie), sender='listeners/http')
+                        listenerName = self.options['Name']['Value']
+                        message = "[*] GET cookie value from {} : {}".format(clientIP, cookie)
+                        signal = json.dumps({
+                            'print': True,
+                            'message': message
+                        })
+                        dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
                         cookieParts = cookie.split(';')
                         for part in cookieParts:
                             if part.startswith('session'):
@@ -987,12 +1007,24 @@ def send_message(packets=None):
                                 # handle_agent_data() signals that the listener should return the stager.ps1 code
 
                                 # step 2 of negotiation -> return stager.ps1 (stage 1)
-                                dispatcher.send("[*] Sending %s stager (stage 1) to %s" % (language, clientIP), sender='listeners/http')
+                                listenerName = self.options['Name']['Value']
+                                message = "[*] Sending {} stager (stage 1) to {}".format(language, clientIP)
+                                signal = json.dumps({
+                                    'print': True,
+                                    'message': message
+                                })
+                                dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
                                 stage = self.generate_stager(language=language, listenerOptions=listenerOptions, obfuscate=self.mainMenu.obfuscate, obfuscationCommand=self.mainMenu.obfuscateCommand)
                                 return make_response(stage, 200)
 
                             elif results.startswith('ERROR:'):
-                                dispatcher.send("[!] Error from agents.handle_agent_data() for %s from %s: %s" % (request_uri, clientIP, results), sender='listeners/http')
+                                listenerName = self.options['Name']['Value']
+                                message = "[!] Error from agents.handle_agent_data() for {} from {}: {}".format(request_uri, clientIP, results)
+                                signal = json.dumps({
+                                    'print': True,
+                                    'message': message
+                                })
+                                dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
 
                                 if 'not in cache' in results:
                                     # signal the client to restage
@@ -1003,7 +1035,13 @@ def send_message(packets=None):
 
                             else:
                                 # actual taskings
-                                dispatcher.send("[*] Agent from %s retrieved taskings" % (clientIP), sender='listeners/http')
+                                listenerName = self.options['Name']['Value']
+                                message = "[*] Agent from %s retrieved taskings".format(clientIP)
+                                signal = json.dumps({
+                                    'print': True,
+                                    'message': message
+                                })
+                                dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
                                 return make_response(results, 200)
                         else:
                             # dispatcher.send("[!] Results are None...", sender='listeners/http')
@@ -1012,7 +1050,13 @@ def send_message(packets=None):
                     return make_response(self.default_response(), 200)
 
             else:
-                dispatcher.send("[!] %s requested by %s with no routing packet." % (request_uri, clientIP), sender='listeners/http')
+                listenerName = self.options['Name']['Value']
+                message = "[!] {} requested by {} with no routing packet.".format(request_uri, clientIP)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
                 return make_response(self.default_response(), 200)
 
         @app.route('/<path:request_uri>', methods=['POST'])
@@ -1025,7 +1069,14 @@ def send_message(packets=None):
             clientIP = request.remote_addr
 
             requestData = request.get_data()
-            dispatcher.send("[*] POST request data length from %s : %s" % (clientIP, len(requestData)), sender='listeners/http')
+
+            listenerName = self.options['Name']['Value']
+            message = "[*] POST request data length from {} : {}".format(clientIP, len(requestData))
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
 
             # the routing packet should be at the front of the binary request.data
             #   NOTE: this can also go into a cookie/etc.
@@ -1039,7 +1090,14 @@ def send_message(packets=None):
                                 clientIP = '[' + str(clientIP) + ']'
                             sessionID = results.split(' ')[1].strip()
                             sessionKey = self.mainMenu.agents.agents[sessionID]['sessionKey']
-                            dispatcher.send("[*] Sending agent (stage 2) to %s at %s" % (sessionID, clientIP), sender='listeners/http')
+
+                            listenerName = self.options['Name']['Value']
+                            message = "[*] Sending agent (stage 2) to {} at {}".format(sessionID, clientIP)
+                            signal = json.dumps({
+                                'print': True,
+                                'message': message
+                            })
+                            dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
 
                             hopListenerName = request.headers.get('Hop-Name')
                             try:
@@ -1057,10 +1115,22 @@ def send_message(packets=None):
                             return make_response(encryptedAgent, 200)
 
                         elif results[:10].lower().startswith('error') or results[:10].lower().startswith('exception'):
-                            dispatcher.send("[!] Error returned for results by %s : %s" %(clientIP, results), sender='listeners/http')
+                            listenerName = self.options['Name']['Value']
+                            message = "[!] Error returned for results by {} : {}".format(clientIP, results)
+                            signal = json.dumps({
+                                'print': True,
+                                'message': message
+                            })
+                            dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
                             return make_response(self.default_response(), 404)
                         elif results == 'VALID':
-                            dispatcher.send("[*] Valid results return by %s" % (clientIP), sender='listeners/http')
+                            listenerName = self.options['Name']['Value']
+                            message = "[*] Valid results return by {}".format(clientIP)
+                            signal = json.dumps({
+                                'print': True,
+                                'message': message
+                            })
+                            dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
                             return make_response(self.default_response(), 404)
                         else:
                             return make_response(results, 200)
@@ -1093,7 +1163,13 @@ def send_message(packets=None):
 
         except Exception as e:
             print helpers.color("[!] Listener startup on port %s failed: %s " % (port, e))
-            dispatcher.send("[!] Listener startup on port %s failed: %s " % (port, e), sender='listeners/http')
+            listenerName = self.options['Name']['Value']
+            message = "[!] Listener startup on port {} failed: {}".format(port, e)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="listeners/http/{}".format(listenerName))
 
     def start(self, name=''):
         """

--- a/lib/listeners/http_com.py
+++ b/lib/listeners/http_com.py
@@ -5,6 +5,7 @@ import os
 import ssl
 import time
 import copy
+import json
 import sys
 from pydispatch import dispatcher
 from flask import Flask, request, make_response
@@ -234,7 +235,7 @@ class Listener:
                         if "https" in host:
                             host = 'https://' + '[' + str(bindIP) + ']' + ":" + str(port)
                         else:
-                            host = 'http://' + '[' + str(bindIP) + ']' + ":" + str(port) 
+                            host = 'http://' + '[' + str(bindIP) + ']' + ":" + str(port)
 
                 # code to turn the key string into a byte array
                 stager += helpers.randomize_capitalization("$K=[System.Text.Encoding]::ASCII.GetBytes(")
@@ -259,7 +260,7 @@ class Listener:
                     for header in customHeaders:
                         headerKey = header.split(':')[0]
                         headerValue = header.split(':')[1]
-                        
+
                         if headerKey.lower() == "host":
                             modifyHost = True
 
@@ -270,7 +271,7 @@ class Listener:
                 #this is a trick to keep the true host name from showing in the TLS SNI portion of the client hello
                 if modifyHost:
                     stager += helpers.randomize_capitalization("$ie.navigate2($ser,$fl,0,$Null,$Null);while($ie.busy){Start-Sleep -Milliseconds 100};")
-                
+
                 stager += "$ie.navigate2($ser+$t,$fl,0,$Null,$c);"
                 stager += "while($ie.busy){Start-Sleep -Milliseconds 100};"
                 stager += "$ht = $ie.document.GetType().InvokeMember('body', [System.Reflection.BindingFlags]::GetProperty, $Null, $ie.document, $Null).InnerHtml;"
@@ -311,7 +312,7 @@ class Listener:
         host = listenerOptions['Host']['Value']
         workingHours = listenerOptions['WorkingHours']['Value']
         customHeaders = profile.split('|')[2:]
-        
+
         # select some random URIs for staging from the main profile
         stage1 = random.choice(uris)
         stage2 = random.choice(uris)
@@ -438,7 +439,7 @@ class Listener:
 
         if language:
             if language.lower() == 'powershell':
-                
+
                 updateServers = """
                     $Script:ControlServers = @("%s");
                     $Script:ServerIndex = 0;
@@ -453,7 +454,7 @@ class Listener:
                     }
 
                 """ % (listenerOptions['Host']['Value'])
-                
+
                 getTask = """
                     function script:Get-Task {
                         try {
@@ -507,7 +508,7 @@ class Listener:
                                 $Headers = ""
                                 $script:Headers.GetEnumerator()| %{ $Headers += "`r`n$($_.Name): $($_.Value)" }
                                 $Headers.TrimStart("`r`n")
-                                
+
                                 try {
                                     # choose a random valid URI for checkin
                                     $taskURI = $script:TaskURIs | Get-Random
@@ -562,7 +563,13 @@ class Listener:
             Before every request, check if the IP address is allowed.
             """
             if not self.mainMenu.agents.is_ip_allowed(request.remote_addr):
-                dispatcher.send("[!] %s on the blacklist/not on the whitelist requested resource" % (request.remote_addr), sender="listeners/http_com")
+                listenerName = self.options['Name']['Value']
+                message = "[!] {} on the blacklist/not on the whitelist requested resource".format(request.remote_addr)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="listeners/http_com/{}".format(listenerName))
                 return make_response(self.default_response(), 200)
 
 
@@ -590,9 +597,16 @@ class Listener:
             This is used during the first step of the staging process,
             and when the agent requests taskings.
             """
-
             clientIP = request.remote_addr
-            dispatcher.send("[*] GET request for %s/%s from %s" % (request.host, request_uri, clientIP), sender='listeners/http_com')
+
+            listenerName = self.options['Name']['Value']
+            message = "[*] GET request for {}/{} from {}".format(request.host, request_uri, clientIP)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="listeners/http_com/{}".format(listenerName))
+
             routingPacket = None
             reqHeader = request.headers.get(listenerOptions['RequestHeader']['Value'])
             if reqHeader and reqHeader != '':
@@ -612,12 +626,24 @@ class Listener:
                                 # handle_agent_data() signals that the listener should return the stager.ps1 code
 
                                 # step 2 of negotiation -> return stager.ps1 (stage 1)
-                                dispatcher.send("[*] Sending %s stager (stage 1) to %s" % (language, clientIP), sender='listeners/http_com')
+                                listenerName = self.options['Name']['Value']
+                                message = "[*] Sending {} stager (stage 1) to {}".format(language, clientIP)
+                                signal = json.dumps({
+                                    'print': True,
+                                    'message': message
+                                })
+                                dispatcher.send(signal, sender="listeners/http_com/{}".format(listenerName))
                                 stage = self.generate_stager(language=language, listenerOptions=listenerOptions, obfuscate=self.mainMenu.obfuscate, obfuscationCommand=self.mainMenu.obfuscateCommand)
                                 return make_response(base64.b64encode(stage), 200)
 
                             elif results.startswith('ERROR:'):
-                                dispatcher.send("[!] Error from agents.handle_agent_data() for %s from %s: %s" % (request_uri, clientIP, results), sender='listeners/http_com')
+                                listenerName = self.options['Name']['Value']
+                                message = "[!] Error from agents.handle_agent_data() for {} from {}: {}".format(request_uri, clientIP, results)
+                                signal = json.dumps({
+                                    'print': True,
+                                    'message': message
+                                })
+                                dispatcher.send(signal, sender="listeners/http_com/{}".format(listenerName))
 
                                 if 'not in cache' in results:
                                     # signal the client to restage
@@ -628,7 +654,13 @@ class Listener:
 
                             else:
                                 # actual taskings
-                                dispatcher.send("[*] Agent from %s retrieved taskings" % (clientIP), sender='listeners/http_com')
+                                listenerName = self.options['Name']['Value']
+                                message = "[*] Agent from {} retrieved taskings".format(clientIP)
+                                signal = json.dumps({
+                                    'print': True,
+                                    'message': message
+                                })
+                                dispatcher.send(signal, sender="listeners/http_com/{}".format(listenerName))
                                 return make_response(base64.b64encode(results), 200)
                         else:
                             # dispatcher.send("[!] Results are None...", sender='listeners/http_com')
@@ -637,7 +669,13 @@ class Listener:
                     return make_response(self.default_response(), 200)
 
             else:
-                dispatcher.send("[!] %s requested by %s with no routing packet." % (request_uri, clientIP), sender='listeners/http_com')
+                listenerName = self.options['Name']['Value']
+                message = "[!] {} requested by {} with no routing packet.".format(request_uri, clientIP)
+                signal = json.dumps({
+                    'print': True,
+                    'message': message
+                })
+                dispatcher.send(signal, sender="listeners/http_com/{}".format(listenerName))
                 return make_response(self.default_response(), 200)
 
 
@@ -665,7 +703,14 @@ class Listener:
                             # TODO: document the exact results structure returned
                             sessionID = results.split(' ')[1].strip()
                             sessionKey = self.mainMenu.agents.agents[sessionID]['sessionKey']
-                            dispatcher.send("[*] Sending agent (stage 2) to %s at %s" % (sessionID, clientIP), sender='listeners/http_com')
+
+                            listenerName = self.options['Name']['Value']
+                            message = "[*] Sending agent (stage 2) to {} at {}".format(sessionID, clientIP)
+                            signal = json.dumps({
+                                'print': True,
+                                'message': message
+                            })
+                            dispatcher.send(signal, sender="listeners/http_com/{}".format(listenerName))
 
                             # step 6 of negotiation -> server sends patched agent.ps1/agent.py
                             agentCode = self.generate_agent(language=language, listenerOptions=listenerOptions, obfuscate=self.mainMenu.obfuscate, obfuscationCommand=self.mainMenu.obfuscateCommand)
@@ -675,10 +720,22 @@ class Listener:
                             return make_response(base64.b64encode(encrypted_agent), 200)
 
                         elif results[:10].lower().startswith('error') or results[:10].lower().startswith('exception'):
-                            dispatcher.send("[!] Error returned for results by %s : %s" %(clientIP, results), sender='listeners/http_com')
+                            listenerName = self.options['Name']['Value']
+                            message = "[!] Error returned for results by {} : {}".format(clientIP, results)
+                            signal = json.dumps({
+                                'print': True,
+                                'message': message
+                            })
+                            dispatcher.send(signal, sender="listeners/http_com/{}".format(listenerName))
                             return make_response(self.default_response(), 200)
                         elif results == 'VALID':
-                            dispatcher.send("[*] Valid results return by %s" % (clientIP), sender='listeners/http_com')
+                            listenerName = self.options['Name']['Value']
+                            message = "[*] Valid results return by {}".format(clientIP)
+                            signal = json.dumps({
+                                'print': True,
+                                'message': message
+                            })
+                            dispatcher.send(signal, sender="listeners/http_com/{}".format(listenerName))
                             return make_response(self.default_response(), 200)
                         else:
                             return make_response(base64.b64encode(results), 200)
@@ -709,8 +766,13 @@ class Listener:
                 app.run(host=bindIP, port=int(port), threaded=True)
 
         except Exception as e:
-            print helpers.color("[!] Listener startup on port %s failed: %s " % (port, e))
-            dispatcher.send("[!] Listener startup on port %s failed: %s " % (port, e), sender='listeners/http_com')
+            listenerName = self.options['Name']['Value']
+            message = "[!] Listener startup on port {} failed: {}".format(port, e)
+            signal = json.dumps({
+                'print': True,
+                'message': message
+            })
+            dispatcher.send(signal, sender="listeners/http_com/{}".format(listenerName))
 
 
     def start(self, name=''):


### PR DESCRIPTION
Instead of manually inserting events into the database, this PR sets up helper functions for common events to make sure they're all identical. This also opens the door to adding more events - I'd like to eventually add some loggers so that whenever a use does something fairly major (new listener, generates agent, etc.) an event is logged.

It also adds a handler onto the dispatcher to log messages from that into the DB automatically, greatly increasing the fidelity of the events table (basically everything the user sees will end up in the events table now).

Breaking changes:
- event bodies are now saved to the DB as JSON instead of plain text descriptions of the event

ALSO, this changes the DB connection method to live in `__init__.py` for the `lib/common` modules - the DB plumbing (with it living on the main menu object) was getting pretty messy so this sets it up globally for everything to use.