### PR TITLE
Add new options for listener management

### DIFF
--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -3088,7 +3088,7 @@ class ListenersMenu(SubMenu):
             print helpers.color("[!] edit <listener name> <option name> <option value> (leave value blank to unset)")
             return
         if len(arguments) == 2:
-            arguments.append(" ")
+            arguments.append("")
         self.mainMenu.listeners.update_listener_options(arguments[0], arguments[1], arguments[2])
         if arguments[0] in self.activeListeners.keys():
             print helpers.color("[*] This change will not take effect until the listener is restarted")

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -2949,6 +2949,21 @@ class ListenersMenu(SubMenu):
         else:
             self.mainMenu.listeners.kill_listener(listenerID)
 
+    def do_delete(self, line):
+        "Delete listener(s) from the database"
+
+        listener_id = line.strip()
+
+        if listener_id.lower() == "all":
+            try:
+                choice = raw_input(helpers.color("[>] Delete all listeners? [y/N] ", "red"))
+                if choice.lower() != '' and choice.lower()[0] == 'y':
+                    self.mainMenu.listeners.delete_listener("all")
+            except KeyboardInterrupt:
+                print ''
+
+        else:
+            self.mainMenu.listeners.delete_listener(listener_id)
 
     def do_usestager(self, line):
         "Use an Empire stager."
@@ -3069,10 +3084,14 @@ class ListenersMenu(SubMenu):
         "Change a listener option, will not take effect until the listener is restarted"
 
         arguments = line.strip().split(" ")
-        if len(arguments) < 3:
-            print helpers.color("[!] edit <listener name> <option name> <option value>")
+        if len(arguments) < 2:
+            print helpers.color("[!] edit <listener name> <option name> <option value> (leave value blank to unset)")
             return
+        if len(arguments) == 2:
+            arguments.append(" ")
         self.mainMenu.listeners.update_listener_options(arguments[0], arguments[1], arguments[2])
+        if arguments[0] in self.activeListeners.keys():
+            print helpers.color("[*] This change will not take effect until the listener is restarted")
 
     def complete_usestager(self, text, line, begidx, endidx):
         "Tab-complete an Empire stager module path."

--- a/lib/common/messages.py
+++ b/lib/common/messages.py
@@ -220,14 +220,14 @@ def display_agent(agent, returnAsString=False):
         print ''
 
 
-def display_active_listeners(listeners):
+def display_listeners(listeners, type = "Active"):
     """
     Take an active listeners list and display everything nicely.
     """
 
     if len(listeners) > 0:
         print ''
-        print helpers.color("[*] Active listeners:\n")
+        print helpers.color("[*] %s listeners:\n" % type)
 
         print "  Name              Module          Host                                 Delay/Jitter   KillDate"
         print "  ----              ------          ----                                 ------------   --------"
@@ -265,7 +265,8 @@ def display_active_listeners(listeners):
         print ''
 
     else:
-        print helpers.color("[!] No listeners currently active ")
+        if(type.lower() != "inactive"):
+            print helpers.color("[!] No listeners currently %s " % type.lower())
 
 
 def display_active_listener(listener):

--- a/setup/setup_database.py
+++ b/setup/setup_database.py
@@ -127,6 +127,7 @@ c.execute('''CREATE TABLE "listeners" (
     "module" text,
     "listener_type" text,
     "listener_category" text,
+    "enabled" boolean,
     "options" blob
     )''')
 


### PR DESCRIPTION
What it says on the tin.

I haven't had a change to test this with redirectors, as I'm not familiar with how Empire manages them yet. I'm pretty sure I didn't do anything that would break them, but if someone could spot-check me I'd appreciate it.

This DOES change the database schema (adding a column to the listeners table).