### PR TITLE
Detect Python virtualenv (install.sh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ There's also a [quickstart here](http://www.powershellempire.com/?page_id=110) a
 
 Contributions are more than welcome! The more people who contribute to the project the better Empire will be for everyone. Below are a few guidelines for submitting contributions.
 
+* Beginning with version 2.4, we will only troubleshoot issues for Kali, Debian, or Ubuntu. All other operating systems will not be supported. We understand that this is frustrating but hopefully the new docker build can provide an alternative.
 * Submit pull requests to the [dev branch](https://github.com/powershellempire/Empire/tree/dev). After testing, changes will be merged to master.
 * Depending on what you're working on, base your module on [./lib/modules/powershell_template.py](lib/modules/powershell_template.py) or [./lib/modules/python_template.py](lib/modules/python_template.py). **Note** that for some modules you may need to massage the output to get it into a nicely displayable text format [with Out-String](https://github.com/PowerShellEmpire/Empire/blob/0cbdb165a29e4a65ad8dddf03f6f0e36c33a7350/lib/modules/situational_awareness/network/powerview/get_user.py#L111).
 * Cite previous work in the **'Comments'** module section.

--- a/empire
+++ b/empire
@@ -864,26 +864,16 @@ def start_restful_api(empireMenu, suppress=False, username=None, password=None, 
         for agentNameID in agentNameIDs:
             [agentName, agentSessionID] = agentNameID
 
-            agentResults = execute_db_query(conn, "SELECT results FROM agents WHERE session_id=?", [agentSessionID])
-            taskIDs = execute_db_query(conn, "SELECT id from taskings where agent=?", [agentSessionID])
+            agentResults = execute_db_query(conn, "SELECT results.id,taskings.data AS command,results.data AS response FROM results INNER JOIN taskings ON results.id = taskings.id AND results.agent = taskings.agent where results.agent=?;", [agentSessionID])
 
-            if agentResults[0][0] and len(agentResults[0][0]) > 0:
-                try:
-                    agentResults = ast.literal_eval(agentResults[0][0])
-                except ValueError:
-                    break
+            results = []
+            if len(agentResults) > 0:
+                for taskID, command, result in agentResults:
+                    results.append({'taskID': taskID, 'command': command, 'results': result})
 
-                results = []
-                if len(agentResults) > 0:
-                    job_outputs = [x.strip() for x in agentResults if not x.startswith('Job')]
-
-                    for taskID, result in zip(taskIDs, job_outputs):
-                        if not (len(result.split('\n')) == 1 and result.endswith('completed!')):
-                            results.append({'taskID': taskID[0], 'results': result})
-                        else:
-                            results.append({'taskID': taskID[0], 'results': ''})
-
-                    agentTaskResults.append({"AgentName": agentSessionID, "AgentResults": results})
+                agentTaskResults.append({"AgentName": agentSessionID, "AgentResults": results})
+            else:
+                agentTaskResults.append({"AgentName": agentSessionID, "AgentResults": []})
 
         return jsonify({'results': agentTaskResults})
 

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -3011,8 +3011,11 @@ class ListenersMenu(SubMenu):
                 stager.options['Listener']['Value'] = listenerName
                 stager.options['Language']['Value'] = language
                 stager.options['Base64']['Value'] = "True"
-                stager.options['Proxy']['Value'] = listenerOptions['options']['Proxy']['Value']
-                stager.options['ProxyCreds']['Value'] = listenerOptions['options']['ProxyCreds']['Value']
+                try:
+                    stager.options['Proxy']['Value'] = listenerOptions['options']['Proxy']['Value']
+                    stager.options['ProxyCreds']['Value'] = listenerOptions['options']['ProxyCreds']['Value']
+                except:
+                    pass
                 if self.mainMenu.obfuscate:
                     stager.options['Obfuscate']['Value'] = "True"
                 else:
@@ -3124,8 +3127,11 @@ class ListenerMenu(SubMenu):
             stager.options['Listener']['Value'] = self.listenerName
             stager.options['Language']['Value'] = parts[0]
             stager.options['Base64']['Value'] = "True"
-            stager.options['Proxy']['Value'] = listenerOptions['options']['Proxy']['Value']
-            stager.options['ProxyCreds']['Value'] = listenerOptions['options']['ProxyCreds']['Value']
+            try:
+                stager.options['Proxy']['Value'] = listenerOptions['options']['Proxy']['Value']
+                stager.options['ProxyCreds']['Value'] = listenerOptions['options']['ProxyCreds']['Value']
+            except:
+                pass
             print stager.generate()
         except Exception as e:
             print helpers.color("[!] Error generating launcher: %s" % (e))

--- a/lib/listeners/dbx.py
+++ b/lib/listeners/dbx.py
@@ -431,7 +431,9 @@ class Listener:
 
 
         elif language.lower() == 'python':
-            template_path = os.path.join(self.mainMenu.installPath, '/data/agent/stagers')
+            template_path = [
+                os.path.join(self.mainMenu.installPath, '/data/agent/stagers'),
+                os.path.join(self.mainMenu.installPath, './data/agent/stagers')]
             eng = templating.TemplateEngine(template_path)
             template = eng.get_template('dropbox.py')
 

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -593,7 +593,9 @@ class Listener:
                 return randomizedStager
 
         elif language.lower() == 'python':
-            template_path = os.path.join(self.mainMenu.installPath, 'data/agent/stagers')
+            template_path = [
+                os.path.join(self.mainMenu.installPath, '/data/agent/stagers'),
+                os.path.join(self.mainMenu.installPath, './data/agent/stagers')]
             eng = templating.TemplateEngine(template_path)
             template = eng.get_template('http.py')
 
@@ -900,7 +902,7 @@ def send_message(packets=None):
                 return launcher
             else:
                 return make_response(self.default_response(), 404)
-        
+
         @app.before_request
         def check_ip():
             """
@@ -932,7 +934,7 @@ def send_message(packets=None):
             """
             Return default server web page if user navigates to index.
             """
-            
+
             static_dir = self.mainMenu.installPath + "data/misc/"
             return make_response(self.index_page(), 200)
 

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -115,9 +115,16 @@ if ! which pip > /dev/null; then
 	python get-pip.py
 fi
 
+# Detect if we're in a virtualenv
+if python -c 'import sys; print sys.real_prefix' 2>/dev/null; then
+	pip_cmd="pip"
+else
+	pip_cmd="sudo pip"
+fi
+
 if uname | grep -q "Darwin"; then
 	install_powershell
-	sudo pip install -r requirements.txt --global-option=build_ext \
+	$pip_cmd install -r requirements.txt --global-option=build_ext \
 		--global-option="-L/usr/local/opt/openssl/lib" \
 		--global-option="-I/usr/local/opt/openssl/include"
 	# In order to build dependencies these should be exproted. 
@@ -129,25 +136,25 @@ else
 	if lsb_release -d | grep -q "Fedora"; then
 		Release=Fedora
 		sudo dnf install -y make g++ python-devel m2crypto python-m2ext swig python-iptools python3-iptools libxml2-devel default-jdk openssl-devel libssl1.0.0 libssl-dev build-essential
-		pip install --upgrade pip
-		sudo pip install -r requirements.txt 
+		$pip_cmd install --upgrade pip
+		$pip_cmd install -r requirements.txt 
 	elif lsb_release -d | grep -q "Kali"; then
 		Release=Kali
 		sudo apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libssl1.0.0 libssl-dev build-essential
-		pip install --upgrade pip
-		sudo pip install -r requirements.txt 
+		$pip_cmd install --upgrade pip
+		$pip_cmd install -r requirements.txt 
 		install_powershell
 	elif lsb_release -d | grep -q "Ubuntu"; then
 		Release=Ubuntu
 		sudo apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libssl1.0.0 libssl-dev build-essential
-		pip install --upgrade pip
-		sudo pip install -r requirements.txt 
+		$pip_cmd install --upgrade pip
+		$pip_cmd install -r requirements.txt 
 		install_powershell
 	else
 		echo "Unknown distro - Debian/Ubuntu Fallback"
 		sudo apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libffi-dev libssl1.0.0 libssl-dev build-essential
-		pip install --upgrade pip
-		sudo pip install -r requirements.txt 
+		$pip_cmd install --upgrade pip
+		$pip_cmd install -r requirements.txt 
 		install_powershell
 	fi
 fi


### PR DESCRIPTION
If we're in active virtualenv "sudo pip" will not see current shell "VIRTUAL_ENV" variable and will install to system global site-packages and mess things up so I added a check to not use sudo if we detected an active python virtualenv