### PR TITLE
Add "report" to main menu, adding some simple reporting

### DIFF
--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -850,10 +850,10 @@ class MainMenu(cmd.Cmd):
     def do_report(self, line):
         "Produce report CSV and log files: sessions.csv, credentials.csv, master.log"
 
-        conn = sqlite3.connect("data/empire.db")
+        self.conn = sqlite3.connect("data/empire.db")
 
         # Agents CSV
-        cur = conn.cursor()
+        cur = self.conn.cursor()
         cur.execute('select session_id, hostname, username, checkin_time from agents')
 
         rows = cur.fetchall()

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -847,6 +847,73 @@ class MainMenu(cmd.Cmd):
                     print helpers.color("[*] " + os.path.basename(file) + " was already obfuscated. Not reobfuscating.")
                 helpers.obfuscate_module(file, self.obfuscateCommand, reobfuscate)
 
+    def do_report(self, line):
+        "Produce report CSV and log files: sessions.csv, credentials.csv, master.log"
+
+        conn = sqlite3.connect("data/empire.db")
+
+        # Agents CSV
+        cur = conn.cursor()
+        cur.execute('select session_id, hostname, username, checkin_time from agents')
+
+        rows = cur.fetchall()
+        print helpers.color("[*] Writing data/sessions.csv")
+        f = open('data/sessions.csv','w')
+        f.write("SessionID, Hostname, User Name, First Check-in\n")
+        for row in rows:
+            f.write(row[0]+ ','+ row[1]+ ','+ row[2]+ ','+ row[3]+'\n')
+        f.close()
+
+        # Credentials CSV
+        cur.execute("""
+        SELECT
+            domain
+            ,username
+            ,host
+            ,credtype
+            ,password
+        FROM
+            credentials
+        ORDER BY
+            domain
+            ,credtype
+            ,host
+        """)
+
+        rows = cur.fetchall()
+        print helpers.color("[*] Writing data/credentials.csv")
+        f = open('data/credentials.csv','w')
+        f.write('Domain, Username, Host, Cred Type, Password\n')
+        for row in rows:
+            f.write(row[0]+ ','+ row[1]+ ','+ row[2]+ ','+ row[3]+ ','+ row[4]+'\n')
+        f.close()
+
+        # Empire Log
+        cur.execute("""
+        SELECT
+            reporting.time_stamp
+            ,reporting.event_type
+            ,reporting.name as "AGENT_ID"
+            ,a.hostname
+            ,reporting.taskID
+            ,t.data AS "Task"
+            ,r.data AS "Results"
+        FROM
+            reporting
+            JOIN agents a on reporting.name = a.session_id
+            LEFT OUTER JOIN taskings t on (reporting.taskID = t.id) AND (reporting.name = t.agent)
+            LEFT OUTER JOIN results r on (reporting.taskID = r.id) AND (reporting.name = r.agent)
+        WHERE
+            reporting.event_type == 'task' OR reporting.event_type == 'checkin'
+        """)
+        rows = cur.fetchall()
+        print helpers.color("[*] Writing data/master.log")
+        f = open('data/master.log', 'w')
+        f.write('Empire Master Taskings & Results Log by timestamp\n')
+        f.write('='*50 + '\n\n')
+        for row in rows:
+            f.write('\n' + row[0] + ' - ' + row[3] + ' (' + row[2] + ')> ' + unicode(row[5]) + '\n' + unicode(row[6]) + '\n')
+        f.close()
 
     def complete_usemodule(self, text, line, begidx, endidx, language=None):
         "Tab-complete an Empire module path."


### PR DESCRIPTION
PR to add database output to csv and log files. Post-engagement (or even mid-engagement) reporting activities are sometimes difficult to call up. Attempting to find first-check in, or see a current/end state of credentials without starting empire can be difficult. More frustrating is trying to develop a "master narrative timeline". Currently each agent records its activity in a agent.log. Trying to add these all together in a master timeline is near impossible without going to the DB. This report function joins multiple tables together and creates the "master.log". Master.log will be updated at a later time to identify when an agent checked in. Currently represented as "none"

**sessions.csv:**

```
SessionID, Hostname, User Name, First Check-in
GDBRXERK,tsu.hitronhub.home,\jeremy,2018-01-27 15:44:14
```

**credentials.csv:**

```
Domain, Username, Host, Cred Type, Password
```

**master.log:**

```
Empire Master Taskings & Results Log by timestamp
==================================================


2018-01-27 15:44:14 - tsu.home (GDBRXERK)> None
None

2018-01-27 15:49:02 - tsu.home (GDBRXERK)> ps
  PID TTY           TIME CMD
 1346 ttys000    0:00.18 /Applications/iTerm.app/Contents/MacOS/iTerm2 --server login -fp bneg

...SNIP...```