### PR TITLE
fixed API listener options handling to prevent unicode errors

### DIFF
--- a/empire
+++ b/empire
@@ -721,7 +721,8 @@ def start_restful_api(empireMenu, suppress=False, username=None, password=None, 
         listenerObject = main.listeners.loadedListeners[listener_type]
         # set all passed options
         for option, values in request.json.iteritems():
-            values = values.encode('utf8')
+            if type(values) != int:
+                values = values.encode('utf8')
             if option == "Name":
                 listenerName = values
 

--- a/empire
+++ b/empire
@@ -721,6 +721,7 @@ def start_restful_api(empireMenu, suppress=False, username=None, password=None, 
         listenerObject = main.listeners.loadedListeners[listener_type]
         # set all passed options
         for option, values in request.json.iteritems():
+            values = values.encode('utf8')
             if option == "Name":
                 listenerName = values
 


### PR DESCRIPTION
See https://github.com/EmpireProject/Empire/issues/965 for details on this issue. Basically, creating a listener through the Empire CLI leads to all options being normal bytearray strings. However, when you create a listener through the API all the listener options are converted to unicode strings instead of normal bytearray strings. This allows the listener to be created, but upon agent connection a stacktrace is thrown and the agent does not work. If you create a listener through the API and only set the Name option, the listener is fine. It's only when you set the Port and Host options through the API that the agent can't connect. This PR fixes that and agents can connect just fine after encoding the listener options as utf8.