### PR TITLE
add support for && and ; characters in python agent

### DIFF
--- a/data/agent/agent.py
+++ b/data/agent/agent.py
@@ -857,6 +857,9 @@ def run_command(command):
     elif ">" in command or ">>" in command or "<" in command or "<<" in command:
         p = subprocess.Popen(command,stdin=None, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
         return ''.join(list(iter(p.stdout.readline, b'')))
+    elif ";" in command or "&&" in command:
+        p = subprocess.Popen(command,stdin=None, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+        return p.communicate()[0].strip()
     else:
         command_parts = []
         command_parts.append(command)


### PR DESCRIPTION
Add support for && and ; characters in shell commands in the Python Empire agent.  This is an enhancement.  Prior behavior did not support shell commands with those characters in them.

**New behavior:**
(Empire: MROXAHQX) > shell ls; uname
(Empire: MROXAHQX) >
Desktop
Documents
Downloads
Music
Pictures
Public
src
Templates
Videos
Linux
 ..Command execution completed.

(Empire: MROXAHQX) > shell ls && uname
(Empire: MROXAHQX) >
Desktop
Documents
Downloads
Music
Pictures
Public
src
Templates
Videos
Linux
 ..Command execution completed.

