### PR TITLE
fix the shellb module, adding support for path

### DIFF
--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -2825,17 +2825,15 @@ except Exception as e:
             print helpers.color("[!] Please provide a valid zipfile path", color="red")
 
     def do_shellb(self, line):
-        """Execute a shell command as a background job"""
+        """Execute a shell command as a background job""" #shellb -p /root/ ls
         cmd = line.split()
         if self.mainMenu.modules.modules['python/management/osx/shellb']:
             module = self.mainMenu.modules.modules['python/management/osx/shellb']
-            if len(cmd) >= 3 and cmd[0]=="-p":
+            if len(cmd) >= 2 and cmd[0]=="-p":
                 # we have a path, set it and remove the values from the cmd
                 module.options['Path']['Value'] = cmd[1]
-                #remove -p and path
-                cmd.remove(cmd[0])
-                cmd.remove(cmd[0])
-            if len(cmd) > 0: # make sure we have a command
+                cmd = cmd[2:]
+            if len(cmd) > 0: # make sure we have a command as it is possible to enter -p and path without command or -p and no command
                 module.options['Command']['Value'] = " ".join(cmd)
                 module.options['Agent']['Value'] = self.mainMenu.agents.get_agent_name_db(self.sessionID)
                 module_menu = ModuleMenu(self.mainMenu, 'python/management/osx/shellb')
@@ -2844,7 +2842,7 @@ except Exception as e:
                 self.mainMenu.agents.save_agent_log(self.sessionID, msg)
                 module_menu.do_execute("")
             else:
-                print helpers.color("[!] Command parameter not found")
+                print helpers.color("[!] Command or Path parameter value not found")
         else:
             print helpers.color("[!] python/management/osx/shellb module not loaded")
             

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -2826,19 +2826,25 @@ except Exception as e:
 
     def do_shellb(self, line):
         """Execute a shell command as a background job"""
-        cmd = line.strip()
+        cmd = line.split()
         if self.mainMenu.modules.modules['python/management/osx/shellb']:
             module = self.mainMenu.modules.modules['python/management/osx/shellb']
-            if line.strip() != '':
-                module.options['Command']['Value'] = line.strip()
-
-            module.options['Agent']['Value'] = self.mainMenu.agents.get_agent_name_db(self.sessionID)
-            module_menu = ModuleMenu(self.mainMenu, 'python/management/osx/shellb')
-            msg = "[*] Tasked agent to execute %s in the background" % (str(module.options['Path']['Value']))
-            print helpers.color(msg,color="green")
-            self.mainMenu.agents.save_agent_log(self.sessionID, msg)
-            module_menu.do_execute("")
-
+            if len(cmd) >= 3 and cmd[0]=="-p":
+                # we have a path, set it and remove the values from the cmd
+                module.options['Path']['Value'] = cmd[1]
+                #remove -p and path
+                cmd.remove(cmd[0])
+                cmd.remove(cmd[0])
+            if len(cmd) > 0: # make sure we have a command
+                module.options['Command']['Value'] = " ".join(cmd)
+                module.options['Agent']['Value'] = self.mainMenu.agents.get_agent_name_db(self.sessionID)
+                module_menu = ModuleMenu(self.mainMenu, 'python/management/osx/shellb')
+                msg = "[*] Tasked agent to execute %s in the background on path %s" % (str(module.options['Command']['Value']),str(module.options['Path']['Value']))
+                print helpers.color(msg,color="green")
+                self.mainMenu.agents.save_agent_log(self.sessionID, msg)
+                module_menu.do_execute("")
+            else:
+                print helpers.color("[!] Command parameter not found")
         else:
             print helpers.color("[!] python/management/osx/shellb module not loaded")
             

--- a/lib/modules/python/management/osx/shellb.py
+++ b/lib/modules/python/management/osx/shellb.py
@@ -47,10 +47,14 @@ class Module:
                 'Value'         :   ''
             },
             'Command' : {
-                # The 'Agent' option is the only one that MUST be in a module
                 'Description'   :   'Command to execute.',
                 'Required'      :   True,
                 'Value'         :   ''
+            },
+            'Path' : {
+                'Description'   :   'Path command should execute in',
+                'Required'      :   True,
+                'Value'         :   '/'
             }
         }
 
@@ -69,14 +73,16 @@ class Module:
                 if option in self.options:
                     self.options[option]['Value'] = value
 
-    def generate(self):
+    def generate(self, obfuscate=False, obfuscationCommand=""):
 
         cmdstring = self.options['Command']['Value']
+        path = self.options['Path']['Value']
         script = """
 import shlex
 arg = shlex.split("%s")
-p = subprocess.Popen(arg, stdout=PIPE)
+path = "%s"
+p = subprocess.Popen(arg, shell=True, cwd=path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 res = p.stdout.read()
 print res
-""" % (cmdstring)
+""" % (cmdstring,path)
         return script


### PR DESCRIPTION
**Reason:**
Currently the shellb module does not perform as expected.  This change fixes bugs and adds in path support (the module seems to look for the path, so that is added in).

**Current behavior:**
  Name    Required    Value                     Description
  ----    --------    -------                   -----------
  Command True                                  Command to execute.
  Agent   True        0P0JQPQU                  Agent to execute module on.

(Empire: python/management/osx/shellb) > set Command ls
(Empire: python/management/osx/shellb) > execute
[>] Module is not opsec safe, run? [y/N] y
[!] Exception: generate() takes exactly 1 argument (3 given)

**New behavior:**
Options:

  Name    Required    Value                     Description
  ----    --------    -------                   -----------
  Path    True        /                         Path command should execute in
  Command True                                  Command to execute.
  Agent   True        AFNUWHAD                  Agent to execute module on.

(Empire: python/management/osx/shellb) > set Command ls
(Empire: python/management/osx/shellb) > set Path /root/
(Empire: python/management/osx/shellb) > execute
(Empire: python/management/osx/shellb) >
job 2 started
(Empire: python/management/osx/shellb) > back
(Empire: AFNUWHAD) > jobs
(Empire: AFNUWHAD) >
Desktop
Documents
Downloads
Music
Pictures
Public
src
Templates
Videos

