### PR TITLE
Fix for #994 (Docker image broken)

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -170,7 +170,7 @@ fi
 chmod 755 bomutils/build/bin/mkbom && sudo cp bomutils/build/bin/mkbom /usr/local/bin/.
 
 # set up the database schema
-./setup_database.py
+python ./setup_database.py
 
 # generate a cert
 ./cert.sh

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -13,3 +13,4 @@ M2Crypto
 jinja2
 cryptography
 pyminifier==2.1
+pycrypto

--- a/setup/reset.sh
+++ b/setup/reset.sh
@@ -18,7 +18,7 @@ then
 	rm ../data/empire.db
 fi
 
-./setup_database.py
+python ./setup_database.py
 cd ..
 
 # remove the debug file if it exists


### PR DESCRIPTION
This is a fix for the docker image, as the automated build (it is automated right?) creates an image that does not work.

I have not built the docker container myself, but I have re-run the install.sh script on it. It reinstalls without errors now, so it should work when being built as well.

EDIT: Didn't read README before submitting. I can't get the dev branch to install correctly on any of my systems, so I am forced to stick with master. I am aware that this needs to be submitted to the dev branch, sorry about that.