### PR TITLE
Refer to the correct build name for debian sources

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -19,7 +19,7 @@ function install_powershell() {
 			# Import the public repository GPG keys
 			curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 			# Register the Microsoft Product feed
-			sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-jessie-prod jessie main" > /etc/apt/sources.list.d/microsoft.list'
+			sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list'
 			# Update the list of products
 			sudo apt-get update
 			# Install PowerShell
@@ -33,7 +33,7 @@ function install_powershell() {
 			# Import the public repository GPG keys
 			curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 			# Register the Microsoft Product feed
-			sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list'
+			sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-jessie-prod jessie main" > /etc/apt/sources.list.d/microsoft.list'
 			# Update the list of products
 			sudo apt-get update
 			# Install PowerShell


### PR DESCRIPTION
I believe the two debian releases (Stretch 9.0, Jessie 8.0) are mixed up in the install script for the powershell section.

This single commit changes that.