### PR TITLE
Added Kerberoast feature to perform a sleep between ticket requests

### DIFF
--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -548,8 +548,8 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
         $OutputFormat = 'John',
 		
         [ValidateRange(0,10000)]
-	    [Int]
-	    $Sleep = 0,
+        [Int]
+        $Sleep = 0,
 
         [Management.Automation.PSCredential]
         [Management.Automation.CredentialAttribute()]
@@ -649,8 +649,7 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
                 $Out.PSObject.TypeNames.Insert(0, 'PowerView.SPNTicket')
                 Write-Output $Out
             }
-			
-			Start-Sleep($Sleep)
+            Start-Sleep($Sleep)
         }
     }
 
@@ -1090,9 +1089,9 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
         [String]
         $SearchScope = 'Subtree',
 
-	    [ValidateRange(0,10000)]
-	    [Int]
-	    $Sleep = 0,
+        [ValidateRange(0,10000)]
+        [Int]
+        $Sleep = 0,
 		
         [ValidateRange(1, 10000)]
         [Int]

--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -659,10 +659,9 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
                 $Out | Add-Member Noteproperty 'ServicePrincipalName' $Ticket.ServicePrincipalName
                 $Out.PSObject.TypeNames.Insert(0, 'PowerView.SPNTicket')
                 Write-Output $Out
-	    
-            	# sleep for our semi-randomized interval
-            	Start-Sleep -Seconds $RandNo.Next((1-$Jitter)*$Delay, (1+$Jitter)*$Delay)
             }
+            # sleep for our semi-randomized interval
+            Start-Sleep -Seconds $RandNo.Next((1-$Jitter)*$Delay, (1+$Jitter)*$Delay)
         }
     }
 

--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -487,6 +487,10 @@ Defaults to 'John'.
 A [Management.Automation.PSCredential] object of alternate credentials
 for connection to the remote domain using Invoke-UserImpersonation.
 
+.PARAMETER Sleep
+
+Specifies the sleep in seconds between ticket requests.
+
 .EXAMPLE
 
 Get-DomainSPNTicket -SPN "HTTP/web.testlab.local"
@@ -542,6 +546,10 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
         [Alias('Format')]
         [String]
         $OutputFormat = 'John',
+		
+        [ValidateRange(0,10000)]
+	    [Int]
+	    $Sleep = 0,
 
         [Management.Automation.PSCredential]
         [Management.Automation.CredentialAttribute()]
@@ -641,6 +649,8 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
                 $Out.PSObject.TypeNames.Insert(0, 'PowerView.SPNTicket')
                 Write-Output $Out
             }
+			
+			Start-Sleep($Sleep)
         }
     }
 
@@ -1021,6 +1031,8 @@ Specifies the scope to search under, Base/OneLevel/Subtree (default of Subtree).
 Specifies the PageSize to set for the LDAP searcher object.
 .PARAMETER ServerTimeLimit
 Specifies the maximum amount of time the server spends searching. Default of 120 seconds.
+.PARAMETER Sleep
+Specifies the sleep in seconds between ticket requests.
 .PARAMETER Tombstone
 Switch. Specifies that the searcher should also return deleted/tombstoned objects.
 .PARAMETER OutputFormat
@@ -1078,6 +1090,10 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
         [String]
         $SearchScope = 'Subtree',
 
+	    [ValidateRange(0,10000)]
+	    [Int]
+	    $Sleep = 0,
+		
         [ValidateRange(1, 10000)]
         [Int]
         $ResultPageSize = 200,
@@ -1121,7 +1137,7 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
 
     PROCESS {
         if ($PSBoundParameters['Identity']) { $UserSearcherArguments['Identity'] = $Identity }
-        Get-DomainUser @UserSearcherArguments | Where-Object {$_.samaccountname -ne 'krbtgt'} | Get-DomainSPNTicket -OutputFormat $OutputFormat
+        Get-DomainUser @UserSearcherArguments | Where-Object {$_.samaccountname -ne 'krbtgt'} | Get-DomainSPNTicket -Sleep $Sleep -OutputFormat $OutputFormat
     }
 
     END {


### PR DESCRIPTION
Configurable sleep using the Sleep (in seconds) parameter between ticket requests to lower the noise the attack creates towards the Kerberos service (event id '4769').