### PR TITLE
Refer to correct release names for debian powershell package sources

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -19,7 +19,7 @@ function install_powershell() {
 			# Import the public repository GPG keys
 			curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 			# Register the Microsoft Product feed
-			sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-jessie-prod jessie main" > /etc/apt/sources.list.d/microsoft.list'
+			sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list'
 			# Update the list of products
 			sudo apt-get update
 			# Install PowerShell
@@ -33,7 +33,7 @@ function install_powershell() {
 			# Import the public repository GPG keys
 			curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 			# Register the Microsoft Product feed
-			sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list'
+			sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-jessie-prod jessie main" > /etc/apt/sources.list.d/microsoft.list'
 			# Update the list of products
 			sudo apt-get update
 			# Install PowerShell


### PR DESCRIPTION
On the correct branch this time I think :) 

Fixes an apparent reversal of stretch and jessie sources.