### PR TITLE
Reduce size and layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,11 +44,8 @@ RUN apt-get update && apt-get install -qy \
     sudo \
     apt-utils \
     lsb-core \
-    python2.7
-
-# cleanup image
-RUN apt-get -qy clean \
-    autoremove
+    python2.7 \
+ && rm -rf /var/lib/apt/lists/*
 
 # build empire from source
 # TODO: When we merge to master set branch to master


### PR DESCRIPTION
Hello,

The clean command should be in the same layer as the install command. Otherwise, the APT cache is stored in the layer of "RUN apt install" and the "RUN apt clean" instruction is not reducing image size.

For more info see : https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run

Regards