### PR TITLE
Reduce image size (Dev Branch)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get -qy clean \
 
 # build empire from source
 # TODO: When we merge to master set branch to master
-RUN git clone -b dev https://github.com/EmpireProject/Empire.git /opt/Empire && \
+RUN git clone --depth=1 -b dev https://github.com/EmpireProject/Empire.git /opt/Empire && \
     cd /opt/Empire/setup/ && \
     ./install.sh && \
     rm -rf /opt/Empire/data/empire*


### PR DESCRIPTION
Hello,

Because we don't need to pull all the git repository, we should use --depth=1 (https://www.git-scm.com/docs/git-clone#git-clone---depthltdepthgt).

This is reducing image size and improving build speed.

Regards