### PR TITLE
Fix for ln: python : file exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install -qy \
     lsb-core \
     python2.7 \
     python-dev \ 
-  && ln -s /usr/bin/python2.7 /usr/bin/python \
+  && ln -sf /usr/bin/python2.7 /usr/bin/python \
   && rm -rf /var/lib/apt/lists/*
 
 # build empire from source


### PR DESCRIPTION
Fix for a weird issue when building Dockerfile : `ln: failed to create symbolic link '/usr/bin/python': File exists`