### PR TITLE
Bugfix utf8 packet length

### DIFF
--- a/data/agent/agent.ps1
+++ b/data/agent/agent.ps1
@@ -281,11 +281,11 @@ function Invoke-Empire {
             switch -regex ($cmd) {
                 '(ls|^dir)' {
                     if ($cmdargs.length -eq "") {
-                        $output = Get-ChildItem -force | select lastwritetime,length,name
+                        $output = Get-ChildItem -force | select mode,@{Name="Owner";Expression={ (Get-Acl $_.FullName).Owner }},lastwritetime,length,name
                     }
                     else {
                         try{
-                            $output = IEX "$cmd $cmdargs -Force -ErrorAction Stop | select lastwritetime,length,name"
+                            $output = IEX "$cmd $cmdargs -Force -ErrorAction Stop | select mode,@{Name="Owner";Expression={ (Get-Acl $_.FullName).Owner }},lastwritetime,length,name"
                         }
                         catch [System.Management.Automation.ActionPreferenceStopException] {
                             $output = "[!] Error: $_ (or cannot be accessed)."

--- a/data/agent/agent.ps1
+++ b/data/agent/agent.ps1
@@ -279,7 +279,7 @@ function Invoke-Empire {
         }
         else {
             switch -regex ($cmd) {
-                '(ls|dir)' {
+                '(ls|^dir)' {
                     if ($cmdargs.length -eq "") {
                         $output = Get-ChildItem -force | select lastwritetime,length,name
                     }
@@ -292,7 +292,7 @@ function Invoke-Empire {
                         }
                     }
                 }
-                '(mv|move|copy|cp|rm|del|rmdir)' {
+                '(mv|move|copy|cp|rm|del|rmdir|mkdir)' {
                     if ($cmdargs.length -ne "") {
                         try {
                             IEX "$cmd $cmdargs -Force -ErrorAction Stop"

--- a/lib/common/packets.py
+++ b/lib/common/packets.py
@@ -164,7 +164,7 @@ def build_task_packet(taskName, data, resultID):
     totalPacket = struct.pack('=H', 1)
     packetNum = struct.pack('=H', 1)
     resultID = struct.pack('=H', resultID)
-    length = struct.pack('=L',len(data))
+    length = struct.pack('=L',len(data.decode('utf-8').encode('utf-8',errors='ignore'))
     return taskType + totalPacket + packetNum + resultID + length + data.decode('utf-8').encode('utf-8',errors='ignore')
 
 

--- a/lib/common/packets.py
+++ b/lib/common/packets.py
@@ -164,7 +164,7 @@ def build_task_packet(taskName, data, resultID):
     totalPacket = struct.pack('=H', 1)
     packetNum = struct.pack('=H', 1)
     resultID = struct.pack('=H', resultID)
-    length = struct.pack('=L',len(data.decode('utf-8').encode('utf-8',errors='ignore'))
+    length = struct.pack('=L',len(data.decode('utf-8').encode('utf-8',errors='ignore')))
     return taskType + totalPacket + packetNum + resultID + length + data.decode('utf-8').encode('utf-8',errors='ignore')
 
 


### PR DESCRIPTION
Hi, during my unicode bug hunting hell #542 :) I found error in data length counting. This issue affect at least linux agents. Without this fix part of the command remains in remainingData part of the packet and its not correctly executed.