### PR TITLE
utf8 encoding fix for agent initial phase

### DIFF
--- a/data/agent/agent.ps1
+++ b/data/agent/agent.ps1
@@ -281,11 +281,11 @@ function Invoke-Empire {
             switch -regex ($cmd) {
                 '(ls|dir)' {
                     if ($cmdargs.length -eq "") {
-                        $output = Get-ChildItem -force | select lastwritetime,length,name
+                        $output = Get-ChildItem -force | select mode,@{Name="Owner";Expression={ (Get-Acl $_.FullName).Owner }},lastwritetime,length,name
                     }
                     else {
                         try{
-                            $output = IEX "$cmd $cmdargs -Force -ErrorAction Stop | select lastwritetime,length,name"
+                            $output = IEX "$cmd $cmdargs -Force -ErrorAction Stop | select mode,@{Name="Owner";Expression={ (Get-Acl $_.FullName).Owner }},lastwritetime,length,name"
                         }
                         catch [System.Management.Automation.ActionPreferenceStopException] {
                             $output = "[!] Error: $_ (or cannot be accessed)."

--- a/data/agent/stagers/dropbox.ps1
+++ b/data/agent/stagers/dropbox.ps1
@@ -52,7 +52,7 @@ function Start-Negotiate {
 
     # try to ignore all errors
     $ErrorActionPreference = "SilentlyContinue";
-    $e=[System.Text.Encoding]::ASCII;
+    $e=[System.Text.Encoding]::UTF8;
 
     $SKB=$e.GetBytes($SK);
     # set up the AES/HMAC crypto

--- a/data/agent/stagers/http.ps1
+++ b/data/agent/stagers/http.ps1
@@ -57,7 +57,7 @@ function Start-Negotiate {
 
     # try to ignore all errors
     $ErrorActionPreference = "SilentlyContinue";
-    $e=[System.Text.Encoding]::ASCII;
+    $e=[System.Text.Encoding]::UTF8;
     $customHeaders = "";
     $SKB=$e.GetBytes($SK);
     # set up the AES/HMAC crypto

--- a/data/agent/stagers/http_com.ps1
+++ b/data/agent/stagers/http_com.ps1
@@ -57,7 +57,7 @@ function Start-Negotiate {
 
     # try to ignore all errors
     $ErrorActionPreference = "SilentlyContinue";
-    $e=[System.Text.Encoding]::ASCII;
+    $e=[System.Text.Encoding]::UTF8;
     $customHeaders = "";
     $SKB=$e.GetBytes($SK);
     # set up the AES/HMAC crypto

--- a/data/agent/stagers/http_mapi.ps1
+++ b/data/agent/stagers/http_mapi.ps1
@@ -52,7 +52,7 @@ function Start-Negotiate {
 
     # try to ignore all errors
     $ErrorActionPreference = "SilentlyContinue";
-    $e=[System.Text.Encoding]::ASCII;
+    $e=[System.Text.Encoding]::UTF8;
 
     $SKB=$e.GetBytes($SK);
     # set up the AES/HMAC crypto

--- a/data/agent/stagers/onedrive.ps1
+++ b/data/agent/stagers/onedrive.ps1
@@ -52,7 +52,7 @@ function Start-Negotiate {
 
     # try to ignore all errors
     $ErrorActionPreference = "SilentlyContinue";
-    $e=[System.Text.Encoding]::ASCII;
+    $e=[System.Text.Encoding]::UTF8;
 
     $SKB=$e.GetBytes($SK);
     # set up the AES/HMAC crypto


### PR DESCRIPTION
During debuging of the issue #1114 i found the agent bug in username utf8 encoding (and probably any other field if utf8 chars are allowed) which is send during initial phase. Tested on http stager but tried to fix on other releveant stagers too.
Without patch:
`(Empire: agents) > list`
`[*] Active agents:`
` Name            Lang  Internal IP     Machine Name    Username            Process             Delay    Last Seen`
`  ---------       ----  -----------     ------------    ---------           -------             -----    --------------------`
`  FN5D2H1X        ps    192.168.122.159 WINNIE-PC       winnie-PC\?????powershell/1864     5/0.0    2018-05-14 15:55:18`

With patch:
`(Empire: agents) > list`
`[*] Active agents:`
` Name            Lang  Internal IP     Machine Name    Username            Process             Delay    Last Seen`
`  ---------       ----  -----------     ------------    ---------           -------             -----    --------------------`
`  YH2ZESRA        ps    192.168.122.159 WINNIE-PC       winnie-PC\ěšřščpowershell/1864     5/0.0    2018-05-14 15:55:18`