### PR TITLE
Fix "ls" command with arguments on Powershell agents.

### DIFF
--- a/data/agent/agent.ps1
+++ b/data/agent/agent.ps1
@@ -285,7 +285,7 @@ function Invoke-Empire {
                     }
                     else {
                         try{
-                            $output = IEX "$cmd $cmdargs -Force -ErrorAction Stop | select mode,@{Name="Owner";Expression={ (Get-Acl $_.FullName).Owner }},lastwritetime,length,name"
+                            $output = IEX "$cmd $cmdargs -Force -ErrorAction Stop | select mode,@{Name=`"Owner`";Expression={ (Get-Acl $_.FullName).Owner }},lastwritetime,length,name"
                         }
                         catch [System.Management.Automation.ActionPreferenceStopException] {
                             $output = "[!] Error: $_ (or cannot be accessed)."


### PR DESCRIPTION
Double quotes in a string to be IEX'd need escaping.