### PR TITLE
Remove listener default value for Port

### DIFF
--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -50,7 +50,7 @@ class Listener:
             'Host' : {
                 'Description'   :   'Hostname/IP for staging.',
                 'Required'      :   True,
-                'Value'         :   "http://%s:%s" % (helpers.lhost(), 80)
+                'Value'         :   "http://%s" % (helpers.lhost())
             },
             'BindIP' : {
                 'Description'   :   'The IP to bind to on the control server.',

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -60,7 +60,7 @@ class Listener:
             'Port' : {
                 'Description'   :   'Port for the listener.',
                 'Required'      :   True,
-                'Value'         :   80
+                'Value'         :   ''
             },
             'Launcher' : {
                 'Description'   :   'Launcher string.',
@@ -402,7 +402,7 @@ class Listener:
                 b64RoutingPacket = base64.b64encode(routingPacket)
 
                 stager += "$ser="+helpers.obfuscate_call_home_address(host)+";$t='"+stage0+"';"
-                
+
                 #Add custom headers if any
                 if customHeaders != []:
                     for header in customHeaders:

--- a/lib/listeners/http_com.py
+++ b/lib/listeners/http_com.py
@@ -48,7 +48,7 @@ class Listener:
             'Host' : {
                 'Description'   :   'Hostname/IP for staging.',
                 'Required'      :   True,
-                'Value'         :   "http://%s:%s" % (helpers.lhost(), 80)
+                'Value'         :   "http://%s" % (helpers.lhost())
             },
             'BindIP' : {
                 'Description'   :   'The IP to bind to on the control server.',

--- a/lib/listeners/http_com.py
+++ b/lib/listeners/http_com.py
@@ -58,7 +58,7 @@ class Listener:
             'Port' : {
                 'Description'   :   'Port for the listener.',
                 'Required'      :   True,
-                'Value'         :   80
+                'Value'         :   ''
             },
             'Launcher' : {
                 'Description'   :   'Launcher string.',

--- a/lib/listeners/http_foreign.py
+++ b/lib/listeners/http_foreign.py
@@ -43,7 +43,7 @@ class Listener:
             'Port' : {
                 'Description'   :   'Port for the listener.',
                 'Required'      :   True,
-                'Value'         :   80
+                'Value'         :   ''
             },
             'Launcher' : {
                 'Description'   :   'Launcher string.',

--- a/lib/listeners/http_foreign.py
+++ b/lib/listeners/http_foreign.py
@@ -38,7 +38,7 @@ class Listener:
             'Host' : {
                 'Description'   :   'Hostname/IP for staging.',
                 'Required'      :   True,
-                'Value'         :   "http://%s:%s" % (helpers.lhost(), 80)
+                'Value'         :   "http://%s" % (helpers.lhost())
             },
             'Port' : {
                 'Description'   :   'Port for the listener.',

--- a/lib/listeners/http_hop.py
+++ b/lib/listeners/http_hop.py
@@ -60,7 +60,7 @@ class Listener:
             'Port' : {
                 'Description'   :   'Port for the listener.',
                 'Required'      :   True,
-                'Value'         :   80
+                'Value'         :   ''
             },
             'DefaultProfile' : {
                 'Description'   :   'Default communication profile for the agent, extracted from RedirectListener automatically.',
@@ -293,7 +293,7 @@ class Listener:
 
                 # add the RC4 packet to a cookie
                 launcherBase += "o.addheaders=[('User-Agent',UA), (\"Cookie\", \"session=%s\")];\n" % (b64RoutingPacket)
-                
+
                 #install proxy and creds globally, so they can be used with urlopen.
                 launcherBase += "urllib2.install_opener(o);\n"
 

--- a/lib/listeners/http_mapi.py
+++ b/lib/listeners/http_mapi.py
@@ -56,7 +56,7 @@ class Listener:
             'Port' : {
                 'Description'   :   'Port for the listener.',
                 'Required'      :   True,
-                'Value'         :   80
+                'Value'         :   ''
             },
             'StagingKey' : {
                 'Description'   :   'Staging key for initial agent negotiation.',

--- a/lib/listeners/http_mapi.py
+++ b/lib/listeners/http_mapi.py
@@ -46,7 +46,7 @@ class Listener:
             'Host' : {
                 'Description'   :   'Hostname/IP for staging.',
                 'Required'      :   True,
-                'Value'         :   "http://%s:%s" % (helpers.lhost(), 80)
+                'Value'         :   "http://%s" % (helpers.lhost())
             },
             'BindIP' : {
                 'Description'   :   'The IP to bind to on the control server.',

--- a/lib/listeners/meterpreter.py
+++ b/lib/listeners/meterpreter.py
@@ -31,12 +31,12 @@ class Listener:
             'Host' : {
                 'Description'   :   'Hostname/IP for staging.',
                 'Required'      :   True,
-                'Value'         :   "http://%s:%s" % (helpers.lhost(), 80)
+                'Value'         :   "http://%s" % (helpers.lhost())
             },
             'Port' : {
                 'Description'   :   'Port for the listener.',
                 'Required'      :   True,
-                'Value'         :   80
+                'Value'         :   ''
             }
         }
 
@@ -73,7 +73,7 @@ class Listener:
         if not language or language.lower() != 'powershell':
             print helpers.color('[!] listeners/http generate_launcher(): only PowerShell is supported at this time')
             return None
-        
+
         if listenerName and (listenerName in self.mainMenu.listeners.activeListeners):
 
             # extract the set options for this instantiated listener
@@ -93,7 +93,7 @@ class Listener:
             msfPayload = 'windows/meterpreter/reverse_http'
             if 'https' in host:
                 msfPayload += 's'
-            
+
             if 'http' in host:
                 parts = host.split(':')
                 host = parts[1].strip('/')

--- a/lib/listeners/template.py
+++ b/lib/listeners/template.py
@@ -39,7 +39,7 @@ class Listener:
             'Host' : {
                 'Description'   :   'Hostname/IP for staging.',
                 'Required'      :   True,
-                'Value'         :   "http://%s:%s" % (helpers.lhost(), 80)
+                'Value'         :   "http://%s" % (helpers.lhost())
             },
             'BindIP' : {
                 'Description'   :   'The IP to bind to on the control server.',
@@ -49,7 +49,7 @@ class Listener:
             'Port' : {
                 'Description'   :   'Port for the listener.',
                 'Required'      :   True,
-                'Value'         :   80
+                'Value'         :   ''
             },
             'Launcher' : {
                 'Description'   :   'Launcher string.',
@@ -138,7 +138,7 @@ class Listener:
         self.threads = {} # used to keep track of any threaded instances of this server
 
         # optional/specific for this module
-        
+
 
         # set the default staging key to the controller db default
         self.options['StagingKey']['Value'] = str(helpers.get_config('staging_key')[0])
@@ -174,7 +174,7 @@ class Listener:
         if not language:
             print helpers.color('[!] listeners/template generate_launcher(): no language specified!')
             return None
-        
+
         if listenerName and (listenerName in self.mainMenu.listeners.activeListeners):
 
             # extract the set options for this instantiated listener
@@ -223,18 +223,18 @@ class Listener:
         """
         Generate just the agent communication code block needed for communications with this listener.
         This is so agents can easily be dynamically updated for the new listener.
-        
+
         This should be implemented for the module.
         """
 
         if language:
             if language.lower() == 'powershell':
-                
+
                 updateServers = """
                     $Script:ControlServers = @("%s");
                     $Script:ServerIndex = 0;
                 """ % (listenerOptions['Host']['Value'])
-                
+
                 getTask = """
                     $script:GetTask = {
 


### PR DESCRIPTION
The logic for `Set Host` checks whether `Port` has been manually specified. If it has, the port remains unchanged. Unfortunately, it means that a user who specifies `Set Host https://192.168.1.1:443` during new listener creation will always have to specify the Port manually; the default value ensures `Port` is always set.

This PR removes the `:Port` from the default value for `Host` and the default value for `Port`. Now, by specifying `Set Host https://192.168.1.1:443`, both values will be set appropriately.

The only negative outcome of this that I can see is users who are accustomed to not specifying either Host or Port when creating a listener.