### PR TITLE
Fix Invoke-PSInject and Invoke-ReflectivePEInjection for Win10 1803

### DIFF
--- a/data/module_source/code_execution/Invoke-DllInjection.ps1
+++ b/data/module_source/code_execution/Invoke-DllInjection.ps1
@@ -123,7 +123,7 @@ http://www.exploit-monday.com
         $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
         # Get a reference to the GetModuleHandle and GetProcAddress methods
         $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
         # Get a handle to the module specified
         $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
         $tmpPtr = New-Object IntPtr

--- a/data/module_source/code_execution/Invoke-ReflectivePEInjection.ps1
+++ b/data/module_source/code_execution/Invoke-ReflectivePEInjection.ps1
@@ -1038,7 +1038,7 @@ $RemoteScriptBlock = {
         $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
         # Get a reference to the GetModuleHandle and GetProcAddress methods
         $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
         # Get a handle to the module specified
         $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
         $tmpPtr = New-Object IntPtr

--- a/data/module_source/code_execution/Invoke-Shellcode.ps1
+++ b/data/module_source/code_execution/Invoke-Shellcode.ps1
@@ -275,7 +275,7 @@ http://www.exploit-monday.com
         $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
         # Get a reference to the GetModuleHandle and GetProcAddress methods
         $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
         # Get a handle to the module specified
         $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
         $tmpPtr = New-Object IntPtr

--- a/data/module_source/collection/Invoke-NetRipper.ps1
+++ b/data/module_source/collection/Invoke-NetRipper.ps1
@@ -167,7 +167,7 @@ function Invoke-NetRipper {
         $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
         # Get a reference to the GetModuleHandle and GetProcAddress methods
         $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
         # Get a handle to the module specified
         $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
         $tmpPtr = New-Object IntPtr

--- a/data/module_source/collection/Invoke-NinjaCopy.ps1
+++ b/data/module_source/collection/Invoke-NinjaCopy.ps1
@@ -911,7 +911,7 @@ $RemoteScriptBlock = {
 	    $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
 	    # Get a reference to the GetModuleHandle and GetProcAddress methods
 	    $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-	    $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+	    $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
 	    # Get a handle to the module specified
 	    $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
 	    $tmpPtr = New-Object IntPtr

--- a/data/module_source/credentials/Invoke-CredentialInjection.ps1
+++ b/data/module_source/credentials/Invoke-CredentialInjection.ps1
@@ -1119,7 +1119,7 @@ function Invoke-CredentialInjection
 	        $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
 	        # Get a reference to the GetModuleHandle and GetProcAddress methods
 	        $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-	        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+	        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
 	        # Get a handle to the module specified
 	        $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
 	        $tmpPtr = New-Object IntPtr
@@ -3021,7 +3021,7 @@ function Invoke-CredentialInjection
 	    $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
 	    # Get a reference to the GetModuleHandle and GetProcAddress methods
 	    $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-	    $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+	    $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
 	    # Get a handle to the module specified
 	    $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
 	    $tmpPtr = New-Object IntPtr

--- a/data/module_source/credentials/Invoke-DCSync.ps1
+++ b/data/module_source/credentials/Invoke-DCSync.ps1
@@ -1307,7 +1307,7 @@ Param(
         $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
         # Get a reference to the GetModuleHandle and GetProcAddress methods
         $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
         # Get a handle to the module specified
         $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
         $tmpPtr = New-Object IntPtr

--- a/data/module_source/credentials/Invoke-Mimikatz.ps1
+++ b/data/module_source/credentials/Invoke-Mimikatz.ps1
@@ -883,7 +883,7 @@ $RemoteScriptBlock = {
         $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
         # Get a reference to the GetModuleHandle and GetProcAddress methods
         $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
         # Get a handle to the module specified
         $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
         $tmpPtr = New-Object IntPtr

--- a/data/module_source/credentials/Invoke-TokenManipulation.ps1
+++ b/data/module_source/credentials/Invoke-TokenManipulation.ps1
@@ -292,7 +292,7 @@ Blog on this script: http://clymb3r.wordpress.com/2013/11/03/powershell-and-toke
         $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
         # Get a reference to the GetModuleHandle and GetProcAddress methods
         $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
         # Get a handle to the module specified
         $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
         $tmpPtr = New-Object IntPtr

--- a/data/module_source/lateral_movement/Invoke-PsExec.ps1
+++ b/data/module_source/lateral_movement/Invoke-PsExec.ps1
@@ -158,7 +158,7 @@ function Invoke-PsExec {
         $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
         # Get a reference to the GetModuleHandle and GetProcAddress methods
         $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
         # Get a handle to the module specified
         $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
         $tmpPtr = New-Object IntPtr

--- a/data/module_source/management/Invoke-PSInject.ps1
+++ b/data/module_source/management/Invoke-PSInject.ps1
@@ -930,7 +930,7 @@ $RemoteScriptBlock = {
         $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
         # Get a reference to the GetModuleHandle and GetProcAddress methods
         $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
         # Get a handle to the module specified
         $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
         $tmpPtr = New-Object IntPtr

--- a/data/module_source/management/Invoke-ReflectivePEInjection.ps1
+++ b/data/module_source/management/Invoke-ReflectivePEInjection.ps1
@@ -1038,7 +1038,7 @@ $RemoteScriptBlock = {
 	    $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
 	    # Get a reference to the GetModuleHandle and GetProcAddress methods
 	    $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-	    $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+	    $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
 	    # Get a handle to the module specified
 	    $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
 	    $tmpPtr = New-Object IntPtr
@@ -2947,3 +2947,4 @@ Function Main
 
 Main
 }
+

--- a/data/module_source/management/Invoke-Vnc.ps1
+++ b/data/module_source/management/Invoke-Vnc.ps1
@@ -872,7 +872,7 @@ $RemoteScriptBlock = {
 	    $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
 	    # Get a reference to the GetModuleHandle and GetProcAddress methods
 	    $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-	    $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+	    $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
 	    # Get a handle to the module specified
 	    $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
 	    $tmpPtr = New-Object IntPtr

--- a/data/module_source/privesc/Get-System.ps1
+++ b/data/module_source/privesc/Get-System.ps1
@@ -150,7 +150,7 @@ function Get-System {
         $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
         # Get a reference to the GetModuleHandle and GetProcAddress methods
         $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
         # Get a handle to the module specified
         $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
         $tmpPtr = New-Object IntPtr

--- a/data/module_source/privesc/Invoke-BypassUAC.ps1
+++ b/data/module_source/privesc/Invoke-BypassUAC.ps1
@@ -260,7 +260,7 @@ function Invoke-BypassUAC
         $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods')
         # Get a reference to the GetModuleHandle and GetProcAddress methods
         $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle')
-        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress')
+        $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]))
         # Get a handle to the module specified
         $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module))
         $tmpPtr = New-Object IntPtr


### PR DESCRIPTION
Windows 10 1803 adds an override on GetProcAddress that accepts a pointer to a handle, so we need to specify which function override we want. We can do this by supplying an array of argument types we want.

Tested on Win7 and Win10 1709 and 1803.