### PR TITLE
fix for #1164

### DIFF
--- a/data/agent/agent.ps1
+++ b/data/agent/agent.ps1
@@ -281,11 +281,11 @@ function Invoke-Empire {
             switch -regex ($cmd) {
                 '(ls|^dir)' {
                     if ($cmdargs.length -eq "") {
-                        $output = Get-ChildItem -force | select mode,lastwritetime,length,name
+                        $output = Get-ChildItem -force | select mode,@{Name="Owner";Expression={(Get-Acl $_.FullName).Owner }},lastwritetime,length,name
                     }
                     else {
                         try{
-                            $output = IEX "$cmd $cmdargs -Force -ErrorAction Stop | select lastwritetime,length,name"
+                            $output = IEX "$cmd $cmdargs -Force -ErrorAction Stop" | select mode,@{Name="Owner";Expression={ (Get-Acl $_.FullName).Owner }},lastwritetime,length,name
                         }
                         catch [System.Management.Automation.ActionPreferenceStopException] {
                             $output = "[!] Error: $_ (or cannot be accessed)."


### PR DESCRIPTION
Hi,
when I search for bug (#1164) in my old PR I found that this PR was reverted (https://github.com/EmpireProject/Empire/commit/71a22a3b9fdc84a2348679d04ff7f5807b8c70ba). But I think that Get-Acl was already in powershell v2. Microsoft remove v2 from their PS doc but at least I found this v2 reference here http://adamringenberg.com/powershell2/get-acl. At least I fixed my previous bug if you don't accept this PR :).