### PR TITLE
Updated install.sh to work with Kali 2018.4

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -14,6 +14,7 @@ function install_powershell() {
 		# Deb 9.x
 		if cat /etc/debian_version | grep 9.* ; then
 			# Install system components
+			sudo apt-get update
 			sudo apt-get install -y apt-transport-https curl
 			# Import the public repository GPG keys
 			curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
@@ -27,6 +28,7 @@ function install_powershell() {
 		# Deb 8.x
 		if cat /etc/debian_version | grep 8.* ; then
 			# Install system components
+			sudo apt-get update
 			sudo apt-get install -y apt-transport-https curl gnupg
 			# Import the public repository GPG keys
 			curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
@@ -40,7 +42,8 @@ function install_powershell() {
 		#Ubuntu 14.x
 		if cat /etc/lsb-release | grep 'DISTRIB_RELEASE=14'; then
 			# Install system components
-			sudo apt-get install -y apt-transport-https curl
+			sudo apt-get update
+			sudo apt-get install -y apt-transport-https curl 
 			# Import the public repository GPG keys
 			curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 			# Register the Microsoft Ubuntu repository
@@ -53,7 +56,8 @@ function install_powershell() {
 		#Ubuntu 16.x
 		if cat /etc/lsb-release | grep 'DISTRIB_RELEASE=16'; then
 			# Install system components
-			sudo apt-get install -y apt-transport-https curl
+			sudo apt-get update
+			sudo apt-get install -y apt-transport-https curl 
 			# Import the public repository GPG keys
 			curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 			# Register the Microsoft Ubuntu repository
@@ -66,7 +70,8 @@ function install_powershell() {
 		#Ubuntu 17.x
 		if  cat /etc/lsb-release | grep 'DISTRIB_RELEASE=17'; then
 			# Install system components
-			sudo apt-get install -y apt-transport-https curl
+			sudo apt-get update
+			sudo apt-get install -y apt-transport-https curl 
 			# Import the public repository GPG keys
 			curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 			# Register the Microsoft Ubuntu repository
@@ -79,6 +84,7 @@ function install_powershell() {
 		#Kali Linux
 		if cat /etc/lsb-release | grep -i 'Kali'; then
 			# Install prerequisites
+			apt-get update
 			apt-get install -y curl gnupg apt-transport-https
 			# Import the public repository GPG keys
 			curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
@@ -119,7 +125,7 @@ if uname | grep -q "Darwin"; then
 	sudo pip install -r requirements.txt --global-option=build_ext \
 		--global-option="-L/usr/local/opt/openssl/lib" \
 		--global-option="-I/usr/local/opt/openssl/include"
-	# In order to build dependencies these should be exproted.
+	# In order to build dependencies these should be exproted. 
 	export LDFLAGS=-L/usr/local/opt/openssl/lib
 	export CPPFLAGS=-I/usr/local/opt/openssl/include
 else
@@ -129,30 +135,31 @@ else
 		Release=Fedora
 		sudo dnf install -y make g++ python-devel m2crypto python-m2ext swig python-iptools python3-iptools libxml2-devel default-jdk openssl-devel libssl1.0.0 libssl-dev build-essential
 		pip install --upgrade pip
-		sudo pip install -r requirements.txt
+		sudo pip install -r requirements.txt 
 	elif lsb_release -d | grep -q "Kali"; then
 		Release=Kali
-    apt-get update
-    apt-get install -y multiarch-support
-		wget http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u7_amd64.deb
-		dpkg -i libssl1.0.0_1.0.1t-1+deb8u7_amd64.deb
+		wget --no-check-certificate https://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1%2Bdeb8u8_amd64.deb
+		dpkg -i libssl1.0.0_1.0.1t-1+deb8u8_amd64.deb
+        # Kali currently uses libicu60, but PowerShell needs 57.
+        wget http://archive.ubuntu.com/ubuntu/pool/main/i/icu/libicu57_57.1-6_amd64.deb
+        dpkg -i libicu57_57.1-6_amd64.deb
+        # Downgrade urllib3 to version 1.22
+        pip install urllib3==1.22
 		sudo apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk zlib1g-dev libssl1.0-dev build-essential libssl1.0-dev libxml2-dev zlib1g-dev
 		pip install --upgrade pip
-		sudo pip install -r requirements.txt
+		sudo pip install -r requirements.txt 
 		install_powershell
 	elif lsb_release -d | grep -q "Ubuntu"; then
 		Release=Ubuntu
-    apt-get update
 		sudo apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libssl1.0.0 libssl-dev build-essential
 		pip install --upgrade pip
-		sudo pip install -r requirements.txt
+		sudo pip install -r requirements.txt 
 		install_powershell
 	else
 		echo "Unknown distro - Debian/Ubuntu Fallback"
-    apt-get update
 		sudo apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk libffi-dev libssl1.0.0 libssl-dev build-essential
 		pip install --upgrade pip
-		sudo pip install -r requirements.txt
+		sudo pip install -r requirements.txt 
 		install_powershell
 	fi
 fi
@@ -168,7 +175,7 @@ git clone https://github.com/hogliux/bomutils.git
 (cd bomutils && make)
 (cd bomutils && make install)
 
-# NIT: This fails on OSX. Leaving it only on Linux instances.
+# NIT: This fails on OSX. Leaving it only on Linux instances. 
 if uname | grep -q "Linux"; then
 	(cd bomutils && make install)
 fi


### PR DESCRIPTION
Made fixes to the three issues that were blocking me from building and running under Kali 2018.4:

+ Install libicu57 as that is what Powershell requires (Kali currently only has libicu60)
+ Downgrade liburl to 1.22 per issue #1266 
+ Correct the libssl1.0.0 url and dpkg invocation per phra's PR #1219 (Supersedes #1219) 


