### PR TITLE
Fix libssl for Kali

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -138,8 +138,9 @@ else
 		sudo pip install -r requirements.txt 
 	elif lsb_release -d | grep -q "Kali"; then
 		Release=Kali
-		wget http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u7_amd64.deb
-		dpkg -i libssl1.0.0_1.0.1t-1+deb8u7_amd64.deb
+		sudo apt install multiarch-support
+		wget http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u8_amd64.deb
+		dpkg -i libssl1.0.0_1.0.1t-1+deb8u8_amd64.deb
 		sudo apt-get install -y make g++ python-dev python-m2crypto swig python-pip libxml2-dev default-jdk zlib1g-dev libssl1.0-dev build-essential libssl1.0-dev libxml2-dev zlib1g-dev
 		pip install --upgrade pip
 		sudo pip install -r requirements.txt 


### PR DESCRIPTION
http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u7_amd64.deb -> 404 error

And pre install multiarch-support because of the following error : 

```Selecting previously unselected package libssl1.0.0:amd64.
dpkg: regarding libssl1.0.0_1.0.1t-1+deb8u8_amd64.deb containing libssl1.0.0:amd64, pre-dependency problem:
 libssl1.0.0 pre-depends on multiarch-support
  multiarch-support is not installed.

dpkg: error processing archive libssl1.0.0_1.0.1t-1+deb8u8_amd64.deb (--install):
 pre-dependency problem - not installing libssl1.0.0:amd64
Errors were encountered while processing:
 libssl1.0.0_1.0.1t-1+deb8u8_amd64.deb```