### PR TITLE
Update Description of Redirector Listener

### DIFF
--- a/lib/listeners/redirector.py
+++ b/lib/listeners/redirector.py
@@ -19,7 +19,7 @@ class Listener:
 
             'Author': ['@xorrior'],
 
-            'Description': ("Internal redirector listener. Active agent required. Listener options will be copied from another existing agent."),
+            'Description': ("Internal redirector listener. Active agent required. Listener options will be copied from another existing agent. Requires the active agent to be in an elevated context."),
 
             # categories - client_server, peer_to_peer, broadcast, third_party
             'Category' : ('peer_to_peer'),


### PR DESCRIPTION
Just a small change to `\lib\listeners\redirector.py`.  Added a line to the description stating that redirector listeners must be run in an elevated context, as per #1296.