### PR TITLE
Update/Fix Invoke-Kerberoast

### DIFF
--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -864,7 +864,7 @@ The raw DirectoryServices.SearchResult object, if -Raw is enabled.
         [Switch]
         $Raw
     )
-
+<#
     DynamicParam {
         $UACValueNames = [Enum]::GetNames($UACEnum)
         # add in the negations
@@ -872,7 +872,7 @@ The raw DirectoryServices.SearchResult object, if -Raw is enabled.
         # create new dynamic parameter
         New-DynamicParameter -Name UACFilter -ValidateSet $UACValueNames -Type ([array])
     }
-
+#>
     BEGIN {
         $SearcherArguments = @{}
         if ($PSBoundParameters['Domain']) { $SearcherArguments['Domain'] = $Domain }
@@ -890,9 +890,9 @@ The raw DirectoryServices.SearchResult object, if -Raw is enabled.
 
     PROCESS {
         #bind dynamic parameter to a friendly variable
-        if ($PSBoundParameters -and ($PSBoundParameters.Count -ne 0)) {
-            New-DynamicParameter -CreateVariables -BoundParameters $PSBoundParameters
-        }
+        #if ($PSBoundParameters -and ($PSBoundParameters.Count -ne 0)) {
+        #    New-DynamicParameter -CreateVariables -BoundParameters $PSBoundParameters
+        #}
 
         if ($UserSearcher) {
             $IdentityFilter = ''


### PR DESCRIPTION
Commenting out, though it looks like it could be removed, two sections that throw errors. New-DynmaicParameter is not a function and I couldn't find it anywhere besides helper scripts on technet. 
Looks like it was first introduced in https://github.com/EmpireProject/Empire/commit/71c795a4489b133cfad7d599f9d92a1004db5934#diff-494cc831008b28a810840a12d052d51e