### PR TITLE
Update Invoke-Kerberoast.ps1

### DIFF
--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -865,14 +865,6 @@ The raw DirectoryServices.SearchResult object, if -Raw is enabled.
         $Raw
     )
 
-    DynamicParam {
-        $UACValueNames = [Enum]::GetNames($UACEnum)
-        # add in the negations
-        $UACValueNames = $UACValueNames | ForEach-Object {$_; "NOT_$_"}
-        # create new dynamic parameter
-        New-DynamicParameter -Name UACFilter -ValidateSet $UACValueNames -Type ([array])
-    }
-
     BEGIN {
         $SearcherArguments = @{}
         if ($PSBoundParameters['Domain']) { $SearcherArguments['Domain'] = $Domain }
@@ -889,10 +881,6 @@ The raw DirectoryServices.SearchResult object, if -Raw is enabled.
     }
 
     PROCESS {
-        #bind dynamic parameter to a friendly variable
-        if ($PSBoundParameters -and ($PSBoundParameters.Count -ne 0)) {
-            New-DynamicParameter -CreateVariables -BoundParameters $PSBoundParameters
-        }
 
         if ($UserSearcher) {
             $IdentityFilter = ''


### PR DESCRIPTION
Addressing two sections that throw errors. Removing them in dev, these are commented out in master if anyone wants to dig in further but New-DynamicParameter is not a function and I couldn't find it anywhere besides helper scripts on technet.
Looks like it was first introduced in https://github.com/EmpireProject/Empire/commit/71c795a4489b133cfad7d599f9d92a1004db5934